### PR TITLE
Use redis connection pooling for connection limited redis instances

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Rodrigo Pimentel, rbp - https://github.com/rbp
 Mr. Grue - https://github.com/mrgrue
 Mark Adamcin, Mashery - https://github.com/adamcin
 Hobson Lane - http://github.com/hobson
+Carson Gee - https://github.com/carsongee

--- a/will/mixins/storage.py
+++ b/will/mixins/storage.py
@@ -22,8 +22,12 @@ class StorageMixin(object):
                     db = url.path[1:]
                 else:
                     db = 0
-
-                self.storage = redis.Redis(host=url.hostname, port=url.port, db=db, password=url.password)
+                max_connections = getattr(settings, 'REDIS_MAX_CONNECTIONS', None)
+                connection_pool = redis.ConnectionPool(
+                    max_connections=max_connections, host=url.hostname,
+                    port=url.port, db=db, password=url.password
+                )
+                self.storage = redis.Redis(connection_pool=connection_pool)
 
     def save(self, key, value):
         if not hasattr(self, "storage"):


### PR DESCRIPTION
We were using the free redis instance and kept running out of connections.  This switches to using connection pooling with an optional max connection option in settings.
