### PR TITLE
Fix ALLOW_INSECURE_HIPCHAT_SERVER setting datatype before checking

### DIFF
--- a/will/settings.py
+++ b/will/settings.py
@@ -119,7 +119,7 @@ def import_settings(quiet=True):
                 pass
             else:
                 settings["TEMPLATE_DIRS"] = []
-        if "ALLOW_INSECURE_HIPCHAT_SERVER" in settings and settings["ALLOW_INSECURE_HIPCHAT_SERVER"].lower() == "true":
+        if "ALLOW_INSECURE_HIPCHAT_SERVER" in settings and str(settings["ALLOW_INSECURE_HIPCHAT_SERVER"]).lower() == "true":
             warn("You are choosing to run will with SSL disabled. This is INSECURE and should NEVER be deployed outside a development environment.")
             settings["ALLOW_INSECURE_HIPCHAT_SERVER"] = True
             settings["REQUESTS_OPTIONS"] = {


### PR DESCRIPTION
ALLOW_INSECURE_HIPCHAT_SERVER is a bool in config.py, but if set in the environment, would be a string. Stringify the setting before calling .lower() to check that it has been set to "true".