### PR TITLE
Fix undefined TEMPLATE_DIRS in settings module

### DIFF
--- a/will/settings.py
+++ b/will/settings.py
@@ -126,8 +126,7 @@ def import_settings(quiet=True):
 
         if "TEMPLATE_DIRS" not in settings:
             if "WILL_TEMPLATE_DIRS_PICKLED" in os.environ:
-                # All good
-                pass
+                settings["TEMPLATE_DIRS"] = os.environ["WILL_TEMPLATE_DIRS_PICKLED"].split(";;")
             else:
                 settings["TEMPLATE_DIRS"] = []
         if "ALLOW_INSECURE_HIPCHAT_SERVER" in settings and\


### PR DESCRIPTION
Even if we have `WILL_TEMPLATE_DIRS_PICKLED` in env, it doesn't mean `settings.TEMPLATE_DIRS` is defined. 
Here an example case.
I do not have `TEMPLATE_DIRS` in my settings. I start Will, it reads settings and stores `WILL_TEMPLATE_DIRS_PICKLED` (with default empty list as value) in my env. Then I restart it - pickled template dirs are still in the env, but I do not have any default value for `TEMPLATE_DIRS` and thus getting "undefined property" error.