### PR TITLE
Load modules by alphabetical order

### DIFF
--- a/will/main.py
+++ b/will/main.py
@@ -353,6 +353,7 @@ To set your %(name)s:
             parent_help_text = None
             for plugin_name, plugin_root in self.plugins_dirs.items():
                 for root, dirs, files in os.walk(plugin_root, topdown=False):
+                    files.sort()
                     for f in files:
                         if f[-3:] == ".py" and f != "__init__.py":
                             try:


### PR DESCRIPTION
We have a lot of plugins and I love to 'share' code between plugins.

This small change is useful if you decide to create a shared file let's say called: a_common.py in your plugin directory which will be the first loaded plugin. This allows you to put common functions there and the other plugins can include and use the shared code. Unfortunately on Linux the os.walk uses arbitrary order, so nothing guarantees that your common file will be loaded before others, which causes an ugly exception.

This small change ensures that the modules will be loaded in an alphabetical order.