### PR TITLE
World Weather Online API endpoint change due to DDoS

### DIFF
--- a/will/plugins/productivity/world_time.py
+++ b/will/plugins/productivity/world_time.py
@@ -23,12 +23,12 @@ class TimePlugin(WillPlugin):
         else:
             if hasattr(settings, "WORLD_WEATHER_ONLINE_V2_KEY"):
                 r = requests.get(
-                    "http://api.worldweatheronline.com/free/v2/tz.ashx?q=%s&format=json&key=%s" %
+                    "http://api2.worldweatheronline.com/free/v2/tz.ashx?q=%s&format=json&key=%s" %
                     (place, settings.WORLD_WEATHER_ONLINE_V2_KEY)
                 )
             elif hasattr(settings, "WORLD_WEATHER_ONLINE_KEY"):
                 r = requests.get(
-                    "http://api.worldweatheronline.com/free/v1/tz.ashx?q=%s&format=json&key=%s" %
+                    "http://api2.worldweatheronline.com/free/v1/tz.ashx?q=%s&format=json&key=%s" %
                     (place, settings.WORLD_WEATHER_ONLINE_KEY)
                 )
             resp = r.json()


### PR DESCRIPTION
See the e-mail below:

Dear API User,

As you all are aware that we have been under constant DDOS attack on our network for last few days. We have tried everything to get our solution back but it seems the attack is not subsiding.

Therefore we request all our API users to please change your request url from http://api.worldweatheronline.com to http://api2.worldweatheronline.com

Thank you,

World Weather Online Team