### PR TITLE
Add PROXY_URL configuration option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Marius Brandt, Webrunners, https://github.com/PrideRage
 Steve Ivy, https://github.com/sivy
 Adam Papai, https://github.com/woohgit
 Jessamyn Smith, https://github.com/jessamynsmith
+Dmitri Muntean, https://github.com/dmuntean

--- a/config.py
+++ b/config.py
@@ -119,3 +119,10 @@ PLUGIN_BLACKLIST = [
 
 # Logging level
 # LOGLEVEL = "DEBUG"
+
+# Proxy settings
+# Use proxy to access hipchat servers
+# Make sure your proxy allows CONNECT method to port 5222
+# PROXY_URL = "http://user:pass@corpproxy.example.com:3128"
+# or
+# PROXY_URL = "http://myproxy:80

--- a/docs/config.md
+++ b/docs/config.md
@@ -33,6 +33,7 @@ Config.py is where all of your non-sensitive settings should go.   This includes
 - `LOGLEVEL`: What logging level to use,
 - `HIPCHAT_SERVER`: if you're using the [HipChat server beta](https://www.hipchat.com/server), the hostname of the server,
 - `ALLOW_INSECURE_HIPCHAT_SERVER`: the option to disable SSL checks (seriously, don't),
+- `PROXY_URL`: Proxy server to use, consider exporting it as `WILL_PROXY_URL` environment variable, if it contains sensitive information
 - and all of your non-sensitive plugin settings.
 
 More expansive documenation on all of those settings is in `config.py`, right where you need it.

--- a/will/listener.py
+++ b/will/listener.py
@@ -15,6 +15,15 @@ class WillXMPPClientMixin(ClientXMPP, RosterMixin, RoomMixin, HipChatMixin):
         logger = logging.getLogger(__name__)
         ClientXMPP.__init__(self, "%s/bot" % settings.USERNAME, settings.PASSWORD)
 
+        if settings.USE_PROXY:
+            self.use_proxy = True
+            self.proxy_config = {
+                'host': settings.PROXY_HOSTNAME,
+                'port': settings.PROXY_PORT,
+                'username': settings.PROXY_USERNAME,
+                'passsword': settings.PROXY_PASSWORD,
+            }
+
         self.rooms = []
         self.default_room = settings.DEFAULT_ROOM
 

--- a/will/settings.py
+++ b/will/settings.py
@@ -1,6 +1,7 @@
 import os
 from utils import show_valid, warn, error, note
 from clint.textui import puts, indent, columns
+from urlparse import urlparse
 
 
 def import_settings(quiet=True):
@@ -33,6 +34,15 @@ def import_settings(quiet=True):
     else:
         settings["HIPCHAT_SERVER"] = "api.hipchat.com"
 
+    if "PROXY_URL" in settings:
+        parsed_proxy_url = urlparse(settings["PROXY_URL"])
+        settings["USE_PROXY"] = True
+        settings["PROXY_HOSTNAME"] = parsed_proxy_url.hostname
+        settings["PROXY_USERNAME"] = parsed_proxy_url.username
+        settings["PROXY_PASSWORD"] = parsed_proxy_url.password
+        settings["PROXY_PORT"] = parsed_proxy_url.port
+    else:
+        settings["USE_PROXY"] = False
     # Import from config
     if not quiet:
         puts("Importing config.py... ")


### PR DESCRIPTION
This allows usage of proxy to connect to HipChat servers. Should be helpful in corporate or any other environments that restrict internet access via proxy.