### PR TITLE
Fix rate-limiting problem when using V2 API

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ Ryan Murfitt, https://github.com/puug
 Piotr 'keNzi' Czajkowski, http://www.videotesty.pl/
 Dmitri Muntean, https://github.com/dmuntean
 Ben lau, Mashery, https://github.com/netjunki
+Martin Grund, https://github.com/grundprinzip

--- a/will/mixins/room.py
+++ b/will/mixins/room.py
@@ -6,7 +6,7 @@ from will import settings
 from will.utils import Bunch
 
 V1_TOKEN_URL = "https://%(server)s/v1/rooms/list?auth_token=%(token)s"
-V2_TOKEN_URL = "https://%(server)s/v2/room?auth_token=%(token)s"
+V2_TOKEN_URL = "https://%(server)s/v2/room?auth_token=%(token)s&expand=items&max-results=1000"
 
 
 class Room(Bunch):
@@ -65,12 +65,7 @@ class RoomMixin(object):
             rooms = resp.json()
 
             for room in rooms["items"]:
-                url = room["links"]["self"] + "?auth_token=%s;expand=xmpp_jid" % (settings.V2_TOKEN,)
-                room_details = requests.get(url, **settings.REQUESTS_OPTIONS).json()
-                # map missing hipchat API v1 data
-                for k, v in room_details.items():
-                    if k not in room:
-                        room[k] = room_details[k]
+
                 room["room_id"] = room["id"]
                 self._available_rooms[room["name"]] = Room(**room)
 


### PR DESCRIPTION
To overcome issues with rate-limiting of the V2 API, the API allows to
expand specific elements of the result. See [1] for more details. This
patch expands the room list when loading it and thus avoids hitting the
API limit very soon.

[1] https://www.hipchat.com/docs/apiv2/expansion