### PR TITLE
Removing trailing spaces, newlines from the message

### DIFF
--- a/will/listener.py
+++ b/will/listener.py
@@ -134,7 +134,7 @@ class WillXMPPClientMixin(ClientXMPP, RosterMixin, RoomMixin, HipChatMixin):
             # we're in group chat and I didn't send it
             or (msg["type"] == "groupchat" and msg['mucnick'] != self.nick)
         ):
-                body = msg["body"]
+                body = msg["body"].strip()
 
                 sent_directly_to_me = False
                 # If it's sent directly to me, strip off "@will" from the start.

--- a/will/listener.py
+++ b/will/listener.py
@@ -139,7 +139,7 @@ class WillXMPPClientMixin(ClientXMPP, RosterMixin, RoomMixin, HipChatMixin):
                 sent_directly_to_me = False
                 # If it's sent directly to me, strip off "@will" from the start.
                 if body[:len(self.handle) + 1].lower() == ("@%s" % self.handle).lower():
-                    body = body[len(self.handle) + 1:].strip()
+                    body = body[len(self.handle) + 1:]
                     msg["body"] = body
 
                     sent_directly_to_me = True


### PR DESCRIPTION
The phone clients sometimes are crazy and sends a lot of accidental <CR>s, especially when it's cold outside and your fingers are frozen..

So remove the trailing spaces and newlines first, before comparing and/or removing the `self.handle`.