### PR TITLE
fixing install command for redis on ubuntu/debian

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ sudo service redis start
 On a Debian (Ubuntu, Mint, KNOPPIX) machine to properly install follow the [Redis Quickstart](http://redis.io/topics/quickstart). But you can start more quickly with:
 
 ```bash
-sudo apt-get install redis
+sudo apt-get install redis-server
 redis-server
 ```
 


### PR DESCRIPTION
sudo apt-get install redis does not work.
But there is a 'redis-server' package.
Changing to 
apt-get install redis-server