### PR TITLE
add Alton to the list of Wills

### DIFF
--- a/docs/improve.md
+++ b/docs/improve.md
@@ -126,6 +126,8 @@ Will's also has had help from lots of coders. Alphabetically:
 If you're looking for plugin inspiration, here are some wills that are open-sourced:
 
 - [BuddyUp's will](https://github.com/buddyup/our-will)
+- [edX's devops will](https://github.com/edx/alton)
+- [edX's fun will](https://github.com/edx/xsy)
 - [GreenKahuna's will](https://github.com/greenkahuna/our-will)
 - [Skoczen's will](https://github.com/buddyup/my-will)
 


### PR DESCRIPTION
We actually have two will bots in use at edX, but [Alton](https://github.com/edx/alton/) is the one who does all the work.  [Xsy](https://github.com/edx/xsy/) is the other one.
