### PR TITLE
Change: allow 1-1 html message (Issue #189)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@ Martin Grund, https://github.com/grundprinzip
 Michiel van Baak, https://github.com/mvanbaak
 Dougal Matthews, https://github.com/d0ugal
 Konrad Aust, https://github.com/ironykins
+Andrew Burdyug, https://github.com/AndrewBurdyug

--- a/will/plugin.py
+++ b/will/plugin.py
@@ -29,7 +29,7 @@ class WillPlugin(EmailMixin, StorageMixin, NaturalTimeMixin, RoomMixin, RosterMi
         if kwargs is None:
             kwargs = {}
 
-        if kwargs.get("html", False) and (message and message['type'] in ('chat', 'normal')):
+        if not kwargs.get("html", False) and (message and message['type'] in ('chat', 'normal')):
             # 1-1 can't have HTML.
             content = html_to_text(content)
         elif kwargs.get("html", True):


### PR DESCRIPTION
Hi! 

Base changes: html_to_text(content)  will execute when "html" is False,
even if message type is 'chat' or 'normal'. 

I'm not sure may be we can delete **and (message and message['type'] in ('chat', 'normal'))** (If it was done only for HipChat) and make this condition much simpler: 

``` python
        if kwargs.get("html", True): 
            # Hipchat is weird about spaces between tags.
            content = re.sub(r'>\s+<', '><', content)
        else:
            content = html_to_text(content)
```

_Kind regards, Andrew B._
