### PR TITLE
Return Room objects when using v1 API.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@ Martin Grund, https://github.com/grundprinzip
 Michiel van Baak, https://github.com/mvanbaak
 Dougal Matthews, https://github.com/d0ugal
 Konrad Aust, https://github.com/ironykins
+J. Cliff Dyer, https://github.com/jcdyer

--- a/will/mixins/room.py
+++ b/will/mixins/room.py
@@ -58,7 +58,7 @@ class RoomMixin(object):
             if r.status_code == requests.codes.unauthorized:
                 raise Exception("V1_TOKEN authentication failed with HipChat")
             for room in r.json()["rooms"]:
-                self._available_rooms[room["name"]] = room
+                self._available_rooms[room["name"]] = Room(**room)
         # Otherwise, grab 'em one-by-one via the v2 api.
         else:
             params = {}

--- a/will/mixins/room.py
+++ b/will/mixins/room.py
@@ -16,10 +16,20 @@ V2_TOKEN_URL = "https://%(server)s/v2/room?auth_token=%(token)s&expand=items"
 class Room(Bunch):
 
     @property
+    def id(self):
+        if 'room_id' in self:
+            # Using API v1
+            return self['room_id']
+        elif 'id' in self:
+            # Using API v2
+            return self['id']
+        else:
+            raise TypeError('Room ID not found')
+
+    @property
     def history(self):
         payload = {"auth_token": settings.V2_TOKEN}
-        room_id = int(self['id'])
-        response = requests.get("https://{1}/v2/room/{0}/history".format(str(room_id),
+        response = requests.get("https://{1}/v2/room/{0}/history".format(str(room.id),
                                                                          settings.HIPCHAT_SERVER),
                                 params=payload, **settings.REQUESTS_OPTIONS)
         data = json.loads(response.text)['items']
@@ -30,10 +40,9 @@ class Room(Bunch):
     @property
     def participants(self):
         payload = {"auth_token": settings.V2_TOKEN}
-        room_id = int(self['id'])
         response = requests.get(
             "https://{1}/v2/room/{0}/participant".format(
-                str(room_id),
+                str(room.id),
                 settings.HIPCHAT_SERVER
             ),
             params=payload,
@@ -58,6 +67,9 @@ class RoomMixin(object):
             if r.status_code == requests.codes.unauthorized:
                 raise Exception("V1_TOKEN authentication failed with HipChat")
             for room in r.json()["rooms"]:
+                # Some integrations expect a particular name for the ID field.
+                # Better to use room.id.
+                room["id"] = room["room_id"]  
                 self._available_rooms[room["name"]] = Room(**room)
         # Otherwise, grab 'em one-by-one via the v2 api.
         else:
@@ -74,6 +86,8 @@ class RoomMixin(object):
                 rooms = resp.json()
 
                 for room in rooms["items"]:
+                    # Some integrations expect a particular name for the ID field.
+                    # Better to use room.id
                     room["room_id"] = room["id"]
                     self._available_rooms[room["name"]] = Room(**room)
 


### PR DESCRIPTION
Previously, the `_available_rooms` dict was populated with `Room`
objects if the v2 API is used, but `dict` objects with v1.  It now
returns `Room` objects in either case.
