### PR TITLE
Updated hiredis version and included venv in .girignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.py[cod]
+venv/
 
 # C extensions
 *.so

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hiredis==0.1.4
+hiredis==0.2.0
 redis==2.10.3
 
 -r requirements.base.txt


### PR DESCRIPTION
- Bumped the hiredis version from 0.1.4 to the newest version of 0.2.0. The new version of hiredis now builds on Windows.
- Included venv/ in the .gitignore file to help with local development.

This is a fix for #198
