### PR TITLE
[#186] Loosen ACL parsing

### DIFF
--- a/will/acl.py
+++ b/will/acl.py
@@ -22,7 +22,9 @@ def get_acl_members(acl):
 def is_acl_allowed(nick, acl):
     for a in acl:
         acl_members = get_acl_members(a)
-        if nick in acl_members or nick.lower() in acl_members:
+        print acl_members
+        print nick
+        if nick in acl_members or nick.lower() in [x.lower() for x in acl_members]:
             return True
 
     return False

--- a/will/acl.py
+++ b/will/acl.py
@@ -22,8 +22,6 @@ def get_acl_members(acl):
 def is_acl_allowed(nick, acl):
     for a in acl:
         acl_members = get_acl_members(a)
-        print acl_members
-        print nick
         if nick in acl_members or nick.lower() in [x.lower() for x in acl_members]:
             return True
 

--- a/will/acl.py
+++ b/will/acl.py
@@ -20,10 +20,9 @@ def get_acl_members(acl):
 
 
 def is_acl_allowed(nick, acl):
-    nick = nick.lower()
     for a in acl:
         acl_members = get_acl_members(a)
-        if nick in acl_members:
+        if nick in acl_members or nick.lower() in acl_members:
             return True
 
     return False

--- a/will/tests/test_acl.py
+++ b/will/tests/test_acl.py
@@ -2,7 +2,7 @@ import unittest
 
 from will.mixins.roster import RosterMixin
 from will import settings
-from will.acl import get_acl_members, is_acl_allowed
+from will.acl import is_acl_allowed
 from mock import patch
 
 
@@ -40,7 +40,7 @@ class TestVerifyAcl(unittest.TestCase):
 
     def setUp(self):
         settings.ACL = {
-            "ENGINEERING_OPS": ["bob", "alice"],
+            "ENGINEERING_OPS": ["bob", "Alice"],
             "engineering_devs": ["eve"]
         }
 
@@ -50,6 +50,7 @@ class TestVerifyAcl(unittest.TestCase):
         self.assertTrue(is_acl_allowed("eve", {"engineering_devs"}))
         self.assertTrue(is_acl_allowed("eve", {"engineering_ops", "engineering_devs"}))
         self.assertTrue(is_acl_allowed("alice", {"engineering_ops", "engineering_devs"}))
+        self.assertTrue(is_acl_allowed("Alice", {"engineering_ops", "engineering_devs"}))
 
     def test_is_acl_allowed_returns_false(self):
         self.assertFalse(is_acl_allowed("eve", {"engineering_ops"}))


### PR DESCRIPTION
Don't be so strict so allow direct case sensitive comparision too. To keep the current functionality I'm keeping the nick.lower() compatibliity. too.