### PR TITLE
remove internal_roster from memory

### DIFF
--- a/will/mixins/roster.py
+++ b/will/mixins/roster.py
@@ -5,9 +5,7 @@ from ..acl import is_acl_allowed
 class RosterMixin(object):
     @property
     def internal_roster(self):
-        if not hasattr(self, "_internal_roster"):
-            self._internal_roster = self.load('will_roster', {})
-        return self._internal_roster
+        return self.load('will_roster', {})
 
     def get_user_by_full_name(self, name):
         for jid, info in self.internal_roster.items():


### PR DESCRIPTION
`internal_roster` looks too much cached.
And "on memory cache" cause problem.
I think `internal_roster` is not need to cache in memory.

With scenario below, this PR solve 2 problem.

scenario
1. start will
2. change name(full name in hipchat)
3. use plugin ( `@will ex` ) in chatroom

problems
- problem1:  `self.internal_roster["MY_JID"]` still old
- problem2: `message.sender` become `None`

```
class ExamplePlugin(WillPlugin):

    @respond_to("^ex")
    def ex(self, message):
        logger.info("=> roster %s" % self.internal_roster["MY_JID"])
        logger.info("=> sender %s" % message.sender)
```
