### PR TITLE
Don't try to import blacklisted modules at all.

### DIFF
--- a/will/main.py
+++ b/will/main.py
@@ -413,14 +413,9 @@ To set your %(name)s:
                                     if b in combined_name:
                                         blacklisted = True
 
-                                try:
+                                # Don't even *try* to load a blacklisted module.
+                                if not blacklisted:
                                     plugin_modules[full_module_name] = imp.load_source(module_name, module_path)
-                                except:
-                                    # If it's blacklisted, don't worry if this blows up.
-                                    if blacklisted:
-                                        pass
-                                    else:
-                                        raise
 
                                 parent_mod = path_components[-2].split("/")[-1]
                                 parent_help_text = parent_mod.title()


### PR DESCRIPTION
If you have a utility package in your plugins directory you'll fire a
ton of "relative import outside a package" errors _regardless_ of the
blacklist settings.  This is sub-optimal.  Let's not even try to load a
blacklisted module.
