### PR TITLE
Bug: available_rooms not updating with apiv2

### DIFF
--- a/will/mixins/hipchat.py
+++ b/will/mixins/hipchat.py
@@ -11,6 +11,7 @@ PRIVATE_MESSAGE_URL = "https://%(server)s/v2/user/%(user_id)s/message?auth_token
 SET_TOPIC_URL = "https://%(server)s/v2/room/%(room_id)s/topic?auth_token=%(token)s"
 USER_DETAILS_URL = "https://%(server)s/v2/user/%(user_id)s?auth_token=%(token)s"
 ALL_USERS_URL = "https://%(server)s/v2/user?auth_token=%(token)s&start-index=%(start_index)s"
+ALL_USERS_URL = "https://%(server)s/v2/user?auth_token=%(token)s&start-index=%(start_index)s&max-results=%(max_results)s"
 
 
 class HipChatMixin(object):
@@ -100,7 +101,8 @@ class HipChatMixin(object):
             # Grab the first roster page, and populate full_roster
             url = ALL_USERS_URL % {"server": settings.HIPCHAT_SERVER,
                                    "token": settings.V2_TOKEN,
-                                   "start_index": 0}
+                                   "start_index": 0,
+                                   "max_results": 1000}
             r = requests.get(url, **settings.REQUESTS_OPTIONS)
             for user in r.json()['items']:
                 full_roster["%s" % (user['id'],)] = user

--- a/will/mixins/hipchat.py
+++ b/will/mixins/hipchat.py
@@ -10,7 +10,6 @@ ROOM_TOPIC_URL = "https://%(server)s/v2/room/%(room_id)s/topic?auth_token=%(toke
 PRIVATE_MESSAGE_URL = "https://%(server)s/v2/user/%(user_id)s/message?auth_token=%(token)s"
 SET_TOPIC_URL = "https://%(server)s/v2/room/%(room_id)s/topic?auth_token=%(token)s"
 USER_DETAILS_URL = "https://%(server)s/v2/user/%(user_id)s?auth_token=%(token)s"
-ALL_USERS_URL = "https://%(server)s/v2/user?auth_token=%(token)s&start-index=%(start_index)s"
 ALL_USERS_URL = "https://%(server)s/v2/user?auth_token=%(token)s&start-index=%(start_index)s&max-results=%(max_results)s"
 
 

--- a/will/mixins/room.py
+++ b/will/mixins/room.py
@@ -63,7 +63,7 @@ class RoomMixin(object):
         else:
             params = {}
             params['start-index'] = 0
-            params['max-results'] = 1000
+            max_results = params['max-results'] = 1000
             url = V2_TOKEN_URL % {"server": settings.HIPCHAT_SERVER,
                                   "token": settings.V2_TOKEN}
             while True:
@@ -78,8 +78,8 @@ class RoomMixin(object):
                     self._available_rooms[room["name"]] = Room(**room)
 
                 logger.info('Got %d rooms', len(rooms['items']))
-                if len(rooms['items']) == params['max-results']:
-                    params['start-index'] += params['max-results']
+                if len(rooms['items']) == max_results:
+                    params['start-index'] += max_results
                 else:
                     break
 

--- a/will/mixins/room.py
+++ b/will/mixins/room.py
@@ -63,7 +63,7 @@ class RoomMixin(object):
         else:
             params = {}
             params['start-index'] = 0
-            max_results = params['max-results'] = 1000
+            params['max-results'] = 1000
             url = V2_TOKEN_URL % {"server": settings.HIPCHAT_SERVER,
                                   "token": settings.V2_TOKEN}
             while True:
@@ -78,8 +78,8 @@ class RoomMixin(object):
                     self._available_rooms[room["name"]] = Room(**room)
 
                 logger.info('Got %d rooms', len(rooms['items']))
-                if len(rooms['items']) == max_results:
-                    params['start-index'] = max_results
+                if len(rooms['items']) == params['max-results']:
+                    params['start-index'] += params['max-results']
                 else:
                     break
 


### PR DESCRIPTION
1.- When Will tries to use apiv2 to get all the rooms from hipchat (apiv1 is already deprecatred and fails most of the times), it hangs on an infinite loop because the start-index is never updated.

2.- the max_results parameter has been added when trying to get all_users on hipchat.py, to avoid multiple calls to the api,