### PR TITLE
Max connections must be int

### DIFF
--- a/will/backends/pubsub/redis_pubsub.py
+++ b/will/backends/pubsub/redis_pubsub.py
@@ -24,7 +24,7 @@ class RedisPubSub(BasePubSub):
             db = url.path[1:]
         else:
             db = 0
-        max_connections = getattr(settings, 'REDIS_MAX_CONNECTIONS', None)
+        max_connections = int(getattr(settings, 'REDIS_MAX_CONNECTIONS', None))
         connection_pool = redis.ConnectionPool(
             max_connections=max_connections, host=url.hostname,
             port=url.port, db=db, password=url.password

--- a/will/storage/redis_storage.py
+++ b/will/storage/redis_storage.py
@@ -20,7 +20,7 @@ class RedisStorage(object):
             db = url.path[1:]
         else:
             db = 0
-        max_connections = getattr(settings, 'REDIS_MAX_CONNECTIONS', None)
+        max_connections = int(getattr(settings, 'REDIS_MAX_CONNECTIONS', None))
         connection_pool = redis.ConnectionPool(
             max_connections=max_connections, host=url.hostname,
             port=url.port, db=db, password=url.password


### PR DESCRIPTION
    export WILL_REDIS_MAX_CONNECTIONS=10
    python start_dev_will.py
    ERROR: Unable to bootstrap pubsub!
    Traceback (most recent call last):
      File "/home/benlau/code/will/will/main.py", line 859, in bootstrap_pubsub_mixin
        self.bootstrap_pubsub()
      File "/home/benlau/code/will/will/mixins/pubsub.py", line 27, in bootstrap_pubsub
        self.pubsub = pubsub_module.bootstrap(settings)
      File "/home/benlau/code/will/will/backends/pubsub/redis_pubsub.py", line 53, in bootstrap
        return RedisPubSub(settings)
      File "/home/benlau/code/will/will/backends/pubsub/redis_pubsub.py", line 30, in __init__
        port=url.port, db=db, password=url.password
      File "/home/benlau/.local/lib/python2.7/site-packages/redis/connection.py", line 837, in __init__
        raise ValueError('"max_connections" must be a positive integer')
    ValueError: "max_connections" must be a positive integer
