### PR TITLE
Rewrite the PagerDuty plugin to use the V2 API and add more features

### DIFF
--- a/will/plugins/devops/pagerduty.py
+++ b/will/plugins/devops/pagerduty.py
@@ -2,155 +2,328 @@ from will.plugin import WillPlugin
 from will.decorators import respond_to, periodic, hear, randomly, route, rendered_template, require_settings
 from will import settings
 
-import datetime
-import pygerduty
+from datetime import datetime, timedelta
+import pypd
 
 
 class PagerDutyPlugin(WillPlugin):
 
+    def __init__(self):
+        if getattr(settings, 'PAGERDUTY_APIV2_KEY', False):
+            pypd.api_key = settings.PAGERDUTY_APIV2_KEY
+
+    def get_email_from_hipchat_id(self, hipchat_id):
+        return self.get_hipchat_user(hipchat_id)['email']
+
+    def get_hipchat_id_from_nick(self, nick):
+        user = self.get_user_by_nick(nick.lstrip('@'))
+        if user:
+            return user['hipchat_id']
+
+        return None
+
     @staticmethod
-    def _associate_pd_user(email_address, pager):
-        try:
-            user = next(pager.users.list(query=email_address, limit=1))
-            return user
-        except StopIteration:
-            return None
+    def get_pagerduty_user(email_address):
+        return pypd.User.find_one(email=email_address)
 
-    def _get_user_email_from_mention_name(self, mention_name):
-        try:
-            u = self.get_user_by_nick(mention_name[1:])
-            email_address = self.get_user(u['hipchat_id'])['email']
-            return email_address
-        except TypeError:
-            return None
+    @require_settings('PAGERDUTY_APIV2_KEY')
+    @respond_to(r'^pd list$')
+    def list_own(self, message):
+        """List all ongoing incidents assigned to you."""
+        sender_email = self.get_email_from_hipchat_id(message.sender['hipchat_id'])
+        pd_user = self.get_pagerduty_user(sender_email)
+        if not pd_user:
+            return self.reply(
+                'I cannot find your PagerDuty user based on your HipChat mail address: {}'.format(sender_email),
+                color='yellow',
+            )
 
-    def _update_incident(self, message, incidents, action, assign_to_email=None):
-        pager = pygerduty.PagerDuty(settings.PAGERDUTY_SUBDOMAIN, settings.PAGERDUTY_API_KEY)
-        email_address = self.get_user(message.sender['hipchat_id'])['email']
-        user = self._associate_pd_user(email_address, pager)
-        if user is None:
-            self.reply("I couldn't find your user :(")
-            return
+        incidents = []
+        for incident in pypd.Incident.find(statuses=['triggered', 'acknowledged'], user_ids=[pd_user['id']]):
+            creation_datetime = datetime.strptime(incident['created_at'], '%Y-%m-%dT%H:%M:%SZ')
+            incidents.append({
+                'status': incident['status'],
+                'html_url': incident['html_url'],
+                'summary': incident['summary'],
+                'assignees': ', '.join([
+                    assignment['assignee']['summary']
+                    for assignment in incident['assignments']
+                ]),
+                'created_at': self.to_natural_day_and_time(creation_datetime, with_timezone=True),
+            })
 
-        # if incident(s) are given
         if incidents:
-            for i in incidents:
-                # for specific incident, use show
-                try:
-                    incident = pager.incidents.show(entity_id=i)
-                except pygerduty.BadRequest as e:
-                    if e.code == 5001:
-                        self.reply("Incident %s was not found." % i, color="yellow")
-                    continue
-                if action == 'ack':
-                    try:
-                        incident.acknowledge(requester_id=user.id)
-                    except pygerduty.BadRequest as e:
-                        if e.code == 1001:
-                            self.reply("%s has been already resolved." % i, color="yellow")
-                        continue
-                elif action == 'resolve':
-                    try:
-                        incident.resolve(requester_id=user.id)
-                    except pygerduty.BadRequest as e:
-                        if e.code == 1001:
-                            self.reply("%s has been already resolved." % i, color="yellow")
-                        continue
-                elif action == 'reassign':
-                    try:
-                        if assign_to_email is not None:
-                            assign_to = self._associate_pd_user(assign_to_email, pager)
-                            if assign_to is None:
-                                self.reply("Coudn't find the PD user for %s :(" % assign_to_email)
-                                return
-                            else:
-                                incident.reassign(user_ids=[assign_to.id], requester_id=user.id)
-                    except pygerduty.BadRequest:
-                        # ignore any error, maybe it worth to log it somewhere
-                        # in the future
-                        continue
-            self.reply("Ok.")
-        # if incident(s) are not given
+            self.say(
+                rendered_template('pagerduty_incidents.html', {'incidents': incidents}),
+                message=message,
+                html=True,
+            )
         else:
-            try:
-                # acknowledge assigned incidents
-                if action == 'ack':
-                    for incident in pager.incidents.list(status='triggered', assigned_to=user):
-                        incident.acknowledge(requester_id=user.id)
-                # acknowledge all incidets
-                elif action == 'ack_all':
-                    for incident in pager.incidents.list(status='triggered'):
-                        incident.acknowledge(requester_id=user.id)
-                # resolve assigned incidents
-                elif action == 'resolve':
-                    for incident in pager.incidents.list(status='acknowledged', assigned_to=user):
-                        incident.resolve(requester_id=user.id)
-                # resolve all incidents
-                elif action == 'resolve_all':
-                    for incident in pager.incidents.list(status='acknowledged'):
-                        incident.resolve(requester_id=user.id)
-                self.reply("Ok.")
-            except pygerduty.BadRequest:
-                # ignore any error, might be acked/resolved
-                pass
+            self.reply('No ongoing incidents found assigned to you')
 
-    @require_settings("PAGERDUTY_SUBDOMAIN", "PAGERDUTY_API_KEY")
-    @respond_to("^pd ack$")
-    def ack_all_assigned_incidents(self, message):
-        self._update_incident(message, None, 'ack')
+    @require_settings('PAGERDUTY_APIV2_KEY')
+    @respond_to(r'^pd list!$')
+    def list_all(self, message):
+        """List all ongoing incidents."""
+        incidents = []
+        for incident in pypd.Incident.find(statuses=['triggered', 'acknowledged']):
+            creation_datetime = datetime.strptime(incident['created_at'], '%Y-%m-%dT%H:%M:%SZ')
+            incidents.append({
+                'status': incident['status'],
+                'html_url': incident['html_url'],
+                'summary': incident['summary'],
+                'assignees': ', '.join([
+                    assignment['assignee']['summary']
+                    for assignment in incident['assignments']
+                ]),
+                'created_at': self.to_natural_day_and_time(creation_datetime, with_timezone=True),
+            })
 
-    @require_settings("PAGERDUTY_SUBDOMAIN", "PAGERDUTY_API_KEY")
-    @respond_to("^pd ack (?P<incidents>[0-9 ]*)")
-    def ack_incidents(self, message, incidents):
-        self._update_incident(message, incidents.split(" "), 'ack')
-
-    @require_settings("PAGERDUTY_SUBDOMAIN", "PAGERDUTY_API_KEY")
-    @respond_to("^pd ack!$")
-    def ack_all_incidents(self, message):
-        self._update_incident(message, None, 'ack_all')
-
-    @require_settings("PAGERDUTY_SUBDOMAIN", "PAGERDUTY_API_KEY")
-    @respond_to("^pd resolve$")
-    def resolve_all_assigned_and_acknowledged_incidents(self, message):
-        self._update_incident(message, None, 'resolve')
-
-    @require_settings("PAGERDUTY_SUBDOMAIN", "PAGERDUTY_API_KEY")
-    @respond_to("^pd resolve (?P<incidents>[0-9 ]*)")
-    def resolve_incidens(self, message, incidents):
-        self._update_incident(message, incidents.split(" "), 'resolve')
-
-    @require_settings("PAGERDUTY_SUBDOMAIN", "PAGERDUTY_API_KEY")
-    @respond_to("^pd resolve!$")
-    def resolve_all_incidents(self, message):
-        self._update_incident(message, None, 'resolve_all')
-
-    @require_settings("PAGERDUTY_SUBDOMAIN", "PAGERDUTY_API_KEY")
-    @respond_to("^pd maintenance (?P<service_name>[\S+ ]+) (?P<interval>[1-9])h$")
-    def set_service_maintenance(self, message, service_name=None, interval=None):
-        if not interval:
-            interval = 1
-        pager = pygerduty.PagerDuty(settings.PAGERDUTY_SUBDOMAIN, settings.PAGERDUTY_API_KEY)
-        for service in pager.services.list(limit=50):
-            if service.name == service_name:
-                user = self._associate_pd_user(self.get_user(message.sender['hipchat_id'])['email'], pager)
-                if user is None:
-                    self.reply("I couldn't find your user :(", color="yellow")
-                    return
-                now = datetime.datetime.utcnow()
-                start_time = now.strftime("%Y-%m-%dT%H:%MZ")
-                end_time = (now + datetime.timedelta(hours=int(interval))).strftime("%Y-%m-%dT%H:%MZ")
-                try:
-                    pager.maintenance_windows.create(service_ids=[service.id], requester_id=user.id,
-                                                     start_time=start_time,
-                                                     end_time=end_time)
-                    self.reply("Ok.")
-                except pygerduty.BadRequest as e:
-                    self.reply("Failed: %s" % e.message, color="yellow")
-
-    @respond_to("^pd reassign (?P<incidents>[0-9 ]+)( )(?P<mention_name>[a-zA-Z@]+)$")
-    def reassign_incidents(self, message, incidents, mention_name):
-        email_address = self._get_user_email_from_mention_name(mention_name)
-        if email_address:
-            self._update_incident(message, incidents.split(" "), 'reassign', email_address)
+        if incidents:
+            self.say(
+                rendered_template('pagerduty_incidents.html', {'incidents': incidents}),
+                message=message,
+                html=True,
+            )
         else:
-            self.reply("Can't find email address for %s" % mention_name)
+            self.reply('No ongoing incidents found')
+
+    @require_settings('PAGERDUTY_APIV2_KEY')
+    @respond_to(r'^pd ack$')
+    def acknowledge_own(self, message):
+        """Acknowledge ongoing incidents assigned to you."""
+        sender_email = self.get_email_from_hipchat_id(message.sender['hipchat_id'])
+        pd_user = self.get_pagerduty_user(sender_email)
+        if not pd_user:
+            return self.reply(
+                'I cannot find your PagerDuty user based on your HipChat mail address: {}'.format(sender_email),
+                color='yellow',
+            )
+
+        acknowledged_incidents = []
+        for incident in pypd.Incident.find(statuses=['triggered'], user_ids=[pd_user['id']]):
+            incident.acknowledge(pd_user['email'])
+            acknowledged_incidents.append(str(incident['incident_number']))
+
+        if acknowledged_incidents:
+            self.reply('Acknowledged {} incidents: {}'.format(len(acknowledged_incidents), ', '.join(acknowledged_incidents)))
+        else:
+            self.reply('No triggered incidents found assigned to you')
+
+    @require_settings('PAGERDUTY_APIV2_KEY')
+    @respond_to(r'^pd ack (?P<incidents>[\w ]+)$')
+    def acknowledge_some(self, message, incidents):
+        """Acknowledge specific incidents."""
+        sender_email = self.get_email_from_hipchat_id(message.sender['hipchat_id'])
+        pd_user = self.get_pagerduty_user(sender_email)
+        if not pd_user:
+            return self.reply(
+                'I cannot find your PagerDuty user based on your HipChat mail address: {}'.format(sender_email),
+                color='yellow',
+            )
+
+        incident_ids = incidents.split(' ')
+        acknowledged_incidents = []
+        for incident in pypd.Incident.find(statuses=['triggered']):
+            if str(incident['incident_number']) not in incident_ids and incident['id'] not in incident_ids:
+                continue
+
+            incident.acknowledge(pd_user['email'])
+            acknowledged_incidents.append(str(incident['incident_number']))
+
+        if acknowledged_incidents:
+            self.reply('Acknowledged {} incidents: {}'.format(len(acknowledged_incidents), ', '.join(acknowledged_incidents)))
+        else:
+            self.reply('No triggered incidents found with the provided IDs')
+
+    @require_settings('PAGERDUTY_APIV2_KEY')
+    @respond_to(r'^pd ack!$')
+    def acknowledge_all(self, message):
+        """Acknowledge all ongoing incidents."""
+        sender_email = self.get_email_from_hipchat_id(message.sender['hipchat_id'])
+        pd_user = self.get_pagerduty_user(sender_email)
+        if not pd_user:
+            return self.reply(
+                'I cannot find your PagerDuty user based on your HipChat mail address: {}'.format(sender_email),
+                color='yellow',
+            )
+
+        acknowledged_incidents = []
+        for incident in pypd.Incident.find(statuses=['triggered']):
+            incident.acknowledge(pd_user['email'])
+            acknowledged_incidents.append(str(incident['incident_number']))
+
+        if acknowledged_incidents:
+            self.reply('Acknowledged {} incidents: {}'.format(len(acknowledged_incidents), ', '.join(acknowledged_incidents)))
+        else:
+            self.reply('No triggered incidents found')
+
+    @require_settings('PAGERDUTY_APIV2_KEY')
+    @respond_to(r'^pd resolve$')
+    def resolve_own(self, message):
+        """Resolve ongoing incidents assigned to you."""
+        sender_email = self.get_email_from_hipchat_id(message.sender['hipchat_id'])
+        pd_user = self.get_pagerduty_user(sender_email)
+        if not pd_user:
+            return self.reply(
+                'I cannot find your PagerDuty user based on your HipChat mail address: {}'.format(sender_email),
+                color='yellow',
+            )
+
+        resolved_incidents = []
+        for incident in pypd.Incident.find(statuses=['triggered', 'acknowledged'], user_ids=[pd_user['id']]):
+            incident.resolve(pd_user['email'])
+            resolved_incidents.append(str(incident['incident_number']))
+
+        if resolved_incidents:
+            self.reply('Resolved {} incidents: {}'.format(len(resolved_incidents), ', '.join(resolved_incidents)))
+        else:
+            self.reply('No ongoing incidents found assigned to you')
+
+    @require_settings('PAGERDUTY_APIV2_KEY')
+    @respond_to(r'^pd resolve (?P<incidents>[\w ]+)$')
+    def resolve_some(self, message, incidents):
+        """Resolve specific incidents."""
+        sender_email = self.get_email_from_hipchat_id(message.sender['hipchat_id'])
+        pd_user = self.get_pagerduty_user(sender_email)
+        if not pd_user:
+            return self.reply(
+                'I cannot find your PagerDuty user based on your HipChat mail address: {}'.format(sender_email),
+                color='yellow',
+            )
+
+        incident_ids = incidents.split(' ')
+        resolved_incidents = []
+        for incident in pypd.Incident.find(statuses=['triggered', 'acknowledged']):
+            if str(incident['incident_number']) not in incident_ids and incident['id'] not in incident_ids:
+                continue
+
+            incident.resolve(pd_user['email'])
+            resolved_incidents.append(str(incident['incident_number']))
+
+        if resolved_incidents:
+            self.reply('Resolved {} incidents: {}'.format(len(resolved_incidents), ', '.join(resolved_incidents)))
+        else:
+            self.reply('No ongoing incidents found with the provided IDs')
+
+    @require_settings('PAGERDUTY_APIV2_KEY')
+    @respond_to(r'^pd resolve!$')
+    def resolve_all(self, message):
+        """Resolve all ongoing incidents."""
+        sender_email = self.get_email_from_hipchat_id(message.sender['hipchat_id'])
+        pd_user = self.get_pagerduty_user(sender_email)
+        if not pd_user:
+            return self.reply(
+                'I cannot find your PagerDuty user based on your HipChat mail address: {}'.format(sender_email),
+                color='yellow',
+            )
+
+        resolved_incidents = []
+        for incident in pypd.Incident.find(statuses=['triggered', 'acknowledged'], user_ids=[pd_user['id']]):
+            incident.resolve(pd_user['email'])
+            resolved_incidents.append(str(incident['incident_number']))
+
+        if resolved_incidents:
+            self.reply('Resolved {} incidents: {}'.format(len(resolved_incidents), ', '.join(resolved_incidents)))
+        else:
+            self.reply('No ongoing incidents found')
+
+    @require_settings('PAGERDUTY_APIV2_KEY')
+    @respond_to(r'^pd reassign (?P<incidents>[\w ]+) (?P<receiver>[a-zA-Z0-9@]+)$')
+    def reassign(self, message, incidents, receiver):
+        """Assign incidents to another person."""
+        sender_email = self.get_email_from_hipchat_id(message.sender['hipchat_id'])
+        pd_user = self.get_pagerduty_user(sender_email)
+        if not pd_user:
+            return self.reply(
+                'I cannot find your PagerDuty user based on your HipChat mail address: {}'.format(sender_email),
+                color='yellow',
+            )
+
+        receiver_id = self.get_hipchat_id_from_nick(receiver)
+        if not receiver_id:
+            return self.reply('I could not find a HipChat user based on "{}"'.format(receiver), color='yellow')
+
+        receiver_email = self.get_email_from_hipchat_id(receiver_id)
+        receiver_pd_user = self.get_pagerduty_user(receiver_email)
+        if not receiver_pd_user:
+            return self.reply(
+                'I could not find a PagerDuty user based on the mail address: {}'.format(receiver_email),
+                color='yellow',
+            )
+
+        incident_ids = incidents.split(' ')
+        reassigned_incidents = []
+        for incident in pypd.Incident.find(statuses=['triggered', 'acknowledged']):
+            if str(incident['incident_number']) not in incident_ids and incident['id'] not in incident_ids:
+                continue
+
+            incident.reassign(pd_user['email'], [receiver_pd_user['id']])
+
+            if pd_user['email'] == receiver_pd_user['email']:
+                # PagerDuty unacknowledges an incident when it's reassigned, so lets
+                # acknowledge it if we are assigning to the person who requested it.
+                incident.acknowledge(pd_user['email'])
+
+            reassigned_incidents.append(str(incident['incident_number']))
+
+        if reassigned_incidents:
+            self.reply('Reassigned {} incidents: {}'.format(len(reassigned_incidents), ', '.join(reassigned_incidents)))
+        else:
+            self.reply('No ongoing incidents found with the provided IDs')
+
+    @require_settings('PAGERDUTY_APIV2_KEY')
+    @respond_to(r'^pd maintenance (?P<service>.+) (?P<interval>[0-9]+[hdw])$')
+    def maintenance(self, message, service, interval):
+        """Create a maintenance window for a service."""
+        sender_email = self.get_email_from_hipchat_id(message.sender['hipchat_id'])
+        pd_user = self.get_pagerduty_user(sender_email)
+        if not pd_user:
+            return self.reply(
+                'I cannot find your PagerDuty user based on your HipChat mail address: {}'.format(sender_email),
+                color='yellow',
+            )
+
+        service_name = service.strip().lower()
+
+        interval_value, interval_unit = int(interval[:-1]), interval[-1]
+        if not interval_value:
+            return self.reply('The time period specified equals to nothing', color='yellow')
+
+        if interval_unit == 'h':
+            interval = timedelta(hours=interval_value)
+        elif interval_unit == 'd':
+            interval = timedelta(days=interval_value)
+        elif interval_unit == 'w':
+            interval = timedelta(weeks=interval_value)
+
+        for i in pypd.Service.find(query=service_name):
+            if i['name'].lower() != service_name:
+                continue
+
+            service = i
+            break
+        else:
+            return self.reply(
+                'I cannot find a service with the name "{}" in PagerDuty'.format(service.strip()),
+                color='yellow',
+            )
+
+        pypd.MaintenanceWindow.create(
+            add_headers={'from': pd_user['email']},
+            data={
+                'start_time': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S-00:00'),
+                'end_time': (datetime.utcnow() + interval).strftime('%Y-%m-%dT%H:%M:%S-00:00'),
+                'services': [{
+                    'id': service['id'],
+                    'type': 'service_reference',
+                }],
+            },
+        )
+
+        self.reply(
+            'Maintenance window for "{}" has been created lasting until {}'.format(
+                service['name'],
+                self.to_natural_day_and_time(datetime.now() + interval, with_timezone=True),
+            ),
+        )

--- a/will/requirements/base.txt
+++ b/will/requirements/base.txt
@@ -17,7 +17,7 @@ python-Levenshtein==0.12.0
 pyasn1-modules==0.0.5
 pyasn1==0.1.7
 pycrypto==2.6.1
-pygerduty==0.28
+pypd==1.1.0
 pytz==2017.2
 PyYAML==3.10
 regex==2017.9.23

--- a/will/scripts/config.py.dist
+++ b/will/scripts/config.py.dist
@@ -64,7 +64,7 @@ PLUGIN_BLACKLIST = [
     "will.plugins.productivity.hangout",   # Because it requires a HANGOUT_URL
     "will.plugins.productivity.bitly",   # Because it requires a BITLY_ACCESS_TOKEN key and the bitly_api library
     "will.plugins.devops.bitbucket_is_up",   # Because most folks use github.
-    "will.plugins.devops.pagerduty",  # Because it requires a PAGERDUTY_SUBDOMAIN and PAGERDUTY_API_KEY key
+    "will.plugins.devops.pagerduty",  # Because it requires a PAGERDUTY_APIV2_KEY key
 ]
 
 # A secret key, used to namespace this instance of will and secure pubsub contents.

--- a/will/templates/pagerduty_incidents.html
+++ b/will/templates/pagerduty_incidents.html
@@ -1,0 +1,16 @@
+<table>
+<tr>
+    <th>Status</th>
+    <th>Incident</th>
+    <th>Assignees</th>
+    <th>Created</th>
+</tr>
+{% for incident in incidents %}
+<tr>
+    <td>{% if incident['status'] == 'triggered' %}Trig{% elif incident['status'] == 'acknowledged' %}Ack{% else %}{{ incident['status']|capitalize }}{% endif %}</td>
+    <td><a href="{{ incident['html_url'] }}">{{ incident['summary'] }}</a></td>
+    <td>{{ incident['assignees'] }}</td>
+    <td>{{ incident['created_at'] }}</td>
+</tr>
+{% endfor %}
+</table>


### PR DESCRIPTION
The PagerDuty V1 API is no longer updated and will cease to exist on February 6th, 2018 but we might as well migrate before then.

This rewrite keeps the same commands as the old plugin but with some added convenience. The relevant changes are:

- Switch to using the pypd library instead of pagerduty for v2 compliance.
- Use the PAGERDUTY_APIV2_KEY setting instead of PAGERDUTY_API_KEY to signify the difference between the two keys.
- Added 'pd list' and 'pd list!' commands for listing your own and all active incidents.
- Functions which previously only took incident numbers as input (ack, resolve and reassign) now also accepts incident IDs.
- Commands which make changes give feedback on what changes they have made instead of always just responding "Ok".
- If a user reassigns an incident to themselves we acknowledge the incident on their behalf, as PagerDuty automatically put it back in the triggered state after an incident is reassigned.
- Maintenance windows can now be created with either hours, days or weeks as provided interval, and the interval number can be multiple digits.