### PR TITLE
[FEATURE] Multiple features and improvements

### DIFF
--- a/will/decorators.py
+++ b/will/decorators.py
@@ -1,4 +1,4 @@
-def respond_to(regex, include_me=False, case_sensitive=False, multiline=False, admin_only=False, acl=set()):
+def respond_to(regex, include_me=True, case_sensitive=False, multiline=False, admin_only=False, acl=set()):
     def wrap(f):
         passed_args = []
 
@@ -34,7 +34,7 @@ def periodic(*sched_args, **sched_kwargs):
     return wrap
 
 
-def hear(regex, include_me=False, case_sensitive=False, multiline=False, admin_only=False, acl=set()):
+def hear(regex, include_me=True, case_sensitive=False, multiline=False, admin_only=False, acl=set()):
     def wrap(f):
         passed_args = []
 

--- a/will/listener.py
+++ b/will/listener.py
@@ -1,5 +1,5 @@
 import logging
-import re
+import re, os
 import threading
 import traceback
 from sleekxmpp import ClientXMPP
@@ -175,12 +175,12 @@ class WillXMPPClientMixin(ClientXMPP, RosterMixin, RoomMixin, HipChatMixin):
                                         traceback.format_exc(),
                                     )
 
-                                    if msg is None or msg["type"] == "groupchat":
-                                        if msg.sender and "nick" in msg.sender:
-                                            content = "@%s %s" % (msg.sender["nick"], content)
-                                        self.send_room_message(msg.room["room_id"], content, color="red")
-                                    elif msg['type'] in ('chat', 'normal'):
-                                        self.send_direct_message(msg.sender["hipchat_id"], content)
+#                                    if msg is None or msg["type"] == "groupchat":
+#                                        if msg.sender and "nick" in msg.sender:
+#                                            content = "@%s %s" % (msg.sender["nick"], content)
+#                                        self.send_room_message(msg.room["room_id"], content, color="red")
+#                                    elif msg['type'] in ('chat', 'normal'):
+                                    self.send_direct_message(os.environ['errormsg_user'], content)
 
                             thread = threading.Thread(target=fn, args=(l, thread_args, search_matches.groupdict()))
                             thread.start()

--- a/will/main.py
+++ b/will/main.py
@@ -131,7 +131,8 @@ class WillBot(EmailMixin, WillXMPPClientMixin, StorageMixin, ScheduleMixin,
                     error_message = "FYI, I ran into some problems while starting up:"
                     for err in errors:
                         error_message += "\n%s\n" % err
-                    self.send_room_message(default_room, error_message, color="yellow")
+#                    self.send_room_message(default_room, error_message, color="yellow")
+                    self.send_direct_message(os.environ['errormsg_user'], error_message)
                     puts(colored.red(error_message))
 
                 while True:

--- a/will/mixins/hipchat.py
+++ b/will/mixins/hipchat.py
@@ -6,6 +6,7 @@ import traceback
 from will import settings
 
 ROOM_NOTIFICATION_URL = "https://%(server)s/v2/room/%(room_id)s/notification?auth_token=%(token)s"
+ROOM_MESSAGE_URL = "https://%(server)s/v2/room/%(room_id)s/message?auth_token=%(token)s"
 ROOM_TOPIC_URL = "https://%(server)s/v2/room/%(room_id)s/topic?auth_token=%(token)s"
 PRIVATE_MESSAGE_URL = "https://%(server)s/v2/user/%(user_id)s/message?auth_token=%(token)s"
 SET_TOPIC_URL = "https://%(server)s/v2/room/%(room_id)s/topic?auth_token=%(token)s"
@@ -68,6 +69,25 @@ class HipChatMixin(object):
             requests.post(url, headers=headers, data=json.dumps(data), **settings.REQUESTS_OPTIONS)
         except:
             logging.critical("Error in send_room_message: \n%s" % traceback.format_exc())
+
+    def send_room_message_normal(self, room_id, message_body, html=False, color="green", notify=False, **kwargs):
+        if kwargs:
+            logging.warn("Unknown keyword args for send_room_message: %s" % kwargs)
+
+        format = "text"
+
+        try:
+            url = ROOM_MESSAGE_URL % {"server": settings.HIPCHAT_SERVER,
+                                           "room_id": room_id,
+                                           "token": settings.V2_TOKEN}
+            data = {
+                "message": message_body,
+            }
+            headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+            requests.post(url, headers=headers, data=json.dumps(data), **settings.REQUESTS_OPTIONS)
+        except:
+            logging.critical("Error in send_room_message: \n%s" % traceback.format_exc())
+
 
     def set_room_topic(self, room_id, topic):
         try:

--- a/will/plugin.py
+++ b/will/plugin.py
@@ -29,7 +29,7 @@ class WillPlugin(EmailMixin, StorageMixin, NaturalTimeMixin, RoomMixin, RosterMi
         content = re.sub(r'>\s+<', '><', content)
         return content
 
-    def say(self, content, message=None, room=None, **kwargs):
+    def say(self, content, message=None, room=None, normal=False, **kwargs):
         # Valid kwargs:
         # color: yellow, red, green, purple, gray, random.  Default is green.
         # html: Display HTML or not. Default is False
@@ -43,11 +43,17 @@ class WillPlugin(EmailMixin, StorageMixin, NaturalTimeMixin, RoomMixin, RosterMi
             except KeyError:
                 logging.error(u'"{0}" is not a room object.'.format(room))
             else:
-                self.send_room_message(room_id, content, **kwargs)
+                if normal:
+                    self.send_room_message_normal(room_id, content, **kwargs)
+                else:
+                    self.send_room_message(room_id, content, **kwargs)
         elif message is None or message["type"] == "groupchat":
             rooms = self._rooms_from_message_and_room(message, room)
             for r in rooms:
-                self.send_room_message(r["room_id"], content, **kwargs)
+                if normal:
+                    self.send_room_message_normal(r["room_id"], content, **kwargs)
+                else:
+                    self.send_room_message(r["room_id"], content, **kwargs)
         else:
             self.send_direct_message(message.sender["hipchat_id"], content, **kwargs)
 


### PR DESCRIPTION
`@hear` default hear yourself. (include_me=False)
Error message now send to specific user instead of in the default channel. The user is set by the os environment variable `errormsg_user`
`say()` function now supports normal=False to send a normal message instead of a notification. This works fine with `/code` or emoji.

Admin/contributor please have a look on this. I understand some features like include_me changes the default behaviour and might break things and cause loops.