### PR TITLE
Candidate fix for #336 and #306

### DIFF
--- a/will/backends/io_adapters/hipchat.py
+++ b/will/backends/io_adapters/hipchat.py
@@ -605,7 +605,7 @@ class HipChatBackend(IOBackend, HipChatRosterMixin, HipChatRoomMixin, StorageMix
                 r = requests.get(url, **settings.REQUESTS_OPTIONS)
 
                 for room in r.json()['items']:
-                    all_rooms["%s" % (room['id'],)] = Channel(
+                    all_rooms["%s" % (room['xmpp_jid'],)] = Channel(
                         id=room["id"],
                         name=room["name"],
                         source=clean_for_pickling(room),


### PR DESCRIPTION
When using a server with more than 1000 rooms, the rooms queried on requests after the initial one are assigned an incorrect key to the channels/rooms dictionary, using 'id' instead of 'xmpp_jid'. This cases errors such as those seen in #336  and #306. This simple change should fix at least some of these, and was confirmed to work in testing with one private (self hosted) instance.