### PR TITLE
Add --backends option to generate_will_project

### DIFF
--- a/docker/will/Dockerfile
+++ b/docker/will/Dockerfile
@@ -1,6 +1,7 @@
 #Pull from will-base
 FROM heywill/will-base:latest
 ARG branch=master
+ARG backends="HipChat Rocket.chat Slack Shell"
 # Maintainer
 # ----------
 LABEL maintainer=mlove@columnit.com 
@@ -8,5 +9,5 @@ LABEL maintainer=mlove@columnit.com
 RUN pip install git+https://github.com/skoczen/will.git@$branch 
 
 WORKDIR $_WILL_HOME
-RUN yes | generate_will_project
+RUN generate_will_project --backends $backends
 CMD $_WILL_HOME/run_will.py

--- a/docker/will/will-py2/Dockerfile
+++ b/docker/will/will-py2/Dockerfile
@@ -2,11 +2,12 @@
 FROM heywill/will-base:2.7-alpine
 ARG repo=https://github.com/skoczen/will.git
 ARG branch=master
+ARG backends="HipChat Rocket.chat Slack Shell"
 # Maintainer
 # ----------
 LABEL maintainer=mlove@columnit.com 
 
 RUN pip install git+$repo@$branch 
 WORKDIR $_WILL_HOME
-RUN yes | generate_will_project
+RUN generate_will_project  --backends $backends
 CMD $_WILL_HOME/run_will.py

--- a/docker/will/will-py3/Dockerfile
+++ b/docker/will/will-py3/Dockerfile
@@ -2,11 +2,12 @@
 FROM heywill/will-base:3.7-alpine
 ARG repo=https://github.com/skoczen/will.git
 ARG branch=master
+ARG backends="HipChat Rocket.chat Slack Shell"
 # Maintainer
 # ----------
 LABEL maintainer=mlove@columnit.com 
 
 RUN pip install git+https://github.com/skoczen/will.git@$branch 
 WORKDIR $_WILL_HOME
-RUN yes | generate_will_project
+RUN generate_will_project  --backends $backends
 CMD $_WILL_HOME/run_will.py

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,6 +120,8 @@ Eventually, you'll reach this screen of joy.  Now, it's time to play!
 
 ![Screen of Joy](img/screen_of_joy.gif)
 
+You can also use `generate_will_project` with the `--backends {Slack,HipChat,Rocket.chat,Shell}` option.
+
 #### Testing will out
 
 Once your will is up and running, hop into any of your chat rooms (or just the terminal), and say hello!


### PR DESCRIPTION
Help:

```
/argh/argh # generate_will_project --help
usage: generate_will_project [-h] [--config-dist-only]
                             [--backends {Slack,HipChat,Rocket.chat,Shell} [{Slack,HipChat,Rocket.chat,Shell} ...]]

optional arguments:
  -h, --help            show this help message and exit
  --config-dist-only    Only output a config.py.dist.
  --backends {Slack,HipChat,Rocket.chat,Shell} [{Slack,HipChat,Rocket.chat,Shell} ...]
                        Choose service backends to support.
```

Standard Use:
```
/argh/argh # generate_will_project --backends HipChat Shell

      ___/-\___
  ___|_________|___
     |         |
     |--O---O--|
     |         |
     |         |
     |  \___/  |
     |_________|

      Will: Hi!

Welcome to the will project generator.


Generating will scaffold...
  /plugins
     __init__.py
     morning.py
  /templates
     blank.html
  .gitignore
  run_will.py
  config.py.dist
/usr/local/lib/python3.6/site-packages/will/scripts/../requirements/hipchat.txt
/usr/local/lib/python3.6/site-packages/will/scripts/../requirements/shell.txt
  requirements.txt
  Procfile
  README.md

Done.

 Your will is now ready to go. Run ./run_will.py to get started!
```

Bad choice:
```
/argh/argh # generate_will_project --backends Stride
usage: generate_will_project [-h] [--config-dist-only]
                             [--backends {Slack,HipChat,Rocket.chat,Shell} [{Slack,HipChat,Rocket.chat,Shell} ...]]
generate_will_project: error: argument --backends: invalid choice: 'Stride' (choose from 'Slack', 'HipChat', 'Rocket.chat', 'Shell')
```

Command line input behavior:

```
/argh/argh/argh # generate_will_project

      ___/-\___
  ___|_________|___
     |         |
     |--O---O--|
     |         |
     |         |
     |  \___/  |
     |_________|

      Will: Hi!

Welcome to the will project generator.


Generating will scaffold...
  /plugins
     __init__.py
     morning.py
  /templates
     blank.html
  .gitignore
  run_will.py
  config.py.dist

Will supports a few different service backends.  Let's set up the ones you want:

  Do you want to enable Slack support? [y/n] n
  Do you want to enable HipChat support? [y/n] y
/usr/local/lib/python3.6/site-packages/will/scripts/../requirements/hipchat.txt
  Do you want to enable Rocket.Chat support? [y/n] nn
Please enter 'y' or 'n'.
  Do you want to enable Rocket.Chat support? [y/n] n
  Do you want to enable Shell support? [y/n] n
  requirements.txt
  Procfile
  README.md

Done.

 Your will is now ready to go. Run ./run_will.py to get started!
```