### PR TITLE
Correct Slack default channel setting

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,3 +51,4 @@ acommasplice, https://github.com/acommasplice
 TaunoTinits, https://github.com/TaunoTinits
 ostracon, https://github.com/ostracon
 mattcl, https://github.com/mattcl
+Boris Peterbarg, https://github.com/reist

--- a/will/backends/io_adapters/slack.py
+++ b/will/backends/io_adapters/slack.py
@@ -178,8 +178,8 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
                 elif "channel" in kwargs:
                     event.channel = self.get_channel_from_name(kwargs["channel"])
                 else:
-                    if hasattr(settings, "SLACK_DEFAULT_ROOM"):
-                        event.channel = self.get_channel_from_name(settings.SLACK_DEFAULT_ROOM)
+                    if hasattr(settings, "SLACK_DEFAULT_CHANNEL"):
+                        event.channel = self.get_channel_from_name(settings.SLACK_DEFAULT_CHANNEL)
                     else:
                         # Set self.me
                         self.people

--- a/will/settings.py
+++ b/will/settings.py
@@ -138,6 +138,7 @@ def import_settings(quiet=True):
             "NAME": "HIPCHAT_NAME",
             "HANDLE": "HIPCHAT_HANDLE",
             "DEFAULT_ROOM": "HIPCHAT_DEFAULT_ROOM",
+            "SLACK_DEFAULT_ROOM": "SLACK_DEFAULT_CHANNEL",
         }
         deprecation_warn_shown = False
         for k, v in DEPRECATED_BUT_MAPPED_SETTINGS.items():


### PR DESCRIPTION
This makes Slack use the correct SLACK_DEFAULT_CHANNEL parameter, and doesn't break for anyone who used what's in the code.