### PR TITLE
Support for slack attachments

### DIFF
--- a/will/backends/io_adapters/slack.py
+++ b/will/backends/io_adapters/slack.py
@@ -303,6 +303,11 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
                         }
                     ]),
                 })
+            elif "attachments" in event.kwargs:
+                data.update({
+                    "text": event.content,
+                    "attachments": json.dumps(event.kwargs["attachments"])
+                })
             else:
                 data.update({
                     "text": event.content,


### PR DESCRIPTION
Added support for passing in a proper list for slack attachments. This can be used in the following fashion:

```python
from will.plugin import WillPlugin
from will.decorators import respond_to


class AttachmentsPlugin(WillPlugin):

    @respond_to("attachments")
    def attachments(self, message):
        attachments = [
            {
                "fallback": "Support ticket #1943",
                "pretext": "A new ticket has been filed",
                "title": "Ticket #1943: Can't reset my password",
                "text": "Help! I tried to reset my password but nothing happened!",
                "color": "#7CD197"
            }
        ]
        self.say("Here's your attachments", message=message, attachments=attachments)
```