### PR TITLE
Improve Slack Connection handling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,3 +51,4 @@ acommasplice, https://github.com/acommasplice
 TaunoTinits, https://github.com/TaunoTinits
 ostracon, https://github.com/ostracon
 mattcl, https://github.com/mattcl
+Ahmed Osman, https://github.com/Ashex 

--- a/will/backends/io_adapters/slack.py
+++ b/will/backends/io_adapters/slack.py
@@ -17,7 +17,7 @@ from will.mixins import SleepMixin, StorageMixin
 from multiprocessing import Process
 from will.abstractions import Event, Message, Person, Channel
 from slackclient import SlackClient
-from slackclient._server import SlackConnectionError
+from slackclient.server import SlackConnectionError
 
 SLACK_SEND_URL = "https://slack.com/api/chat.postMessage"
 SLACK_SET_TOPIC_URL = "https://slack.com/api/channels.setTopic"

--- a/will/requirements/slack.txt
+++ b/will/requirements/slack.txt
@@ -1,4 +1,4 @@
 -r base.txt
-slackclient>=1.0.5<1.1.0
+slackclient>=1.2.1<1.3.0
 markdownify==0.4.1
 


### PR DESCRIPTION
This PR covers a couple things:

* The most recent releases of the slackapi library include an auto reconnect flag which has been added in.
* RTM disconnects either throw `WebSocketConnectionClosedException` or `SlackConnectionError`. I've added the second missing exception to the handling as presently will just loses its connection and never tries to reconnect. I've also tweak the import for websockets so that only the exception is imported.
* Raise version requirement of slackapi to current release.