### PR TITLE
Update requirements files

### DIFF
--- a/will/requirements/base.txt
+++ b/will/requirements/base.txt
@@ -14,8 +14,8 @@ MarkupSafe==0.23
 will-natural==0.2.1.1
 parsedatetime==1.1.2
 python-Levenshtein==0.12.0
-pyasn1-modules==0.0.5
-pyasn1==0.1.7
+pyasn1-modules>=0.0.5,<=0.1.5
+pyasn1>=0.1.8,<=0.3.7
 pycrypto==2.6.1
 pygerduty==0.28
 pytz==2017.2

--- a/will/requirements/base.txt
+++ b/will/requirements/base.txt
@@ -22,7 +22,7 @@ pytz==2017.2
 PyYAML==3.10
 regex==2017.9.23
 redis==2.10.6
-requests==2.18.4
+requests>=2.19.1,<3
 six==1.10.0
 urllib3[secure]
 websocket-client==0.44.0

--- a/will/requirements/slack.txt
+++ b/will/requirements/slack.txt
@@ -1,4 +1,4 @@
 -r base.txt
-slackclient>=1.2.1<1.3.0
+slackclient>=1.2.1,<1.3.0
 markdownify==0.4.1
 


### PR DESCRIPTION
Fixes #366 

- Updated the version of `requests` to work with the latest version of `urllib3`.
- Updated `pyasn1` to work with newer versions of `ldap3`. Cannot update to the latest due to compatibility issues with `sleekxmpp`. See: etingof/pyasn1#112