### PR TITLE
Slack File Upload Support

### DIFF
--- a/will/backends/io_adapters/slack.py
+++ b/will/backends/io_adapters/slack.py
@@ -291,7 +291,7 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
             except:
                 logging.info(traceback.format_exc().split(" ")[-1])
                 pass
-                
+
         if event["type"] == "upload_file" and "channel" in event:
             data.update({
                 "channels": str("#" + self.get_channel_name_from_id(channel_id)),

--- a/will/plugin.py
+++ b/will/plugin.py
@@ -87,6 +87,32 @@ class WillPlugin(EmailMixin, StorageMixin, NaturalTimeMixin, HipChatRoomMixin, H
                 logging.info("putting in queue: %s" % content)
                 self.publish("message.outgoing.%s" % backend, e)
 
+    def upload_file(self, content, message=None, room=None, channel=None, service=None, package_for_scheduling=False, **kwargs):
+        if channel:
+            room = channel
+        elif room:
+            channel = room
+
+        if not "channel" in kwargs and channel:
+            kwargs["channels"] = channel
+
+        message = self.get_message(message)
+        message = self._trim_for_execution(message)
+        backend = self.get_backend(message, service=service)
+
+        if backend:
+            e = Event(
+                type="upload_file",
+                content=content,
+                source_message=message,
+                kwargs=kwargs,
+            )
+            if package_for_scheduling:
+                return "message.outgoing.%s" % backend, e
+            else:
+                logging.info("putting in queue: %s" % content)
+                self.publish("message.outgoing.%s" % backend, e)
+
     def reply(self, event, content=None, message=None, package_for_scheduling=False, **kwargs):
         message = self.get_message(message)
 


### PR DESCRIPTION
This feature is pretty self explanatory. I've implemented what should be complete support for file uploads. You can send both files and text based snippets to slack. 

File based uploads are supported in that a binary bytes stream should be passed to `content`, I've tested this with `io.BytesIO()`

```python
        content = 'I\'m a lumberjack and I\'m OK \n \
                          I sleep all night and I work all day'
        self.upload_file(content=content,
                         filetype='text',
                         initial_comment="I made you a snippet, do you like it?",
                         title="Text based snippet",
                         message=message)
```


It would be great to get another person to test this. It's working in the bot I'm managing but I wrote this feature roughly 6 weeks ago and only just got around to porting this to my clean repo for the PR.