### PR TITLE
Added Slack Channel Whitelist

### DIFF
--- a/will/mixins/slackwhitelist.py
+++ b/will/mixins/slackwhitelist.py
@@ -1,0 +1,144 @@
+# Whitelist allows you to configure a list of channels that are whitelisted.
+# Use this to control what commands are allowed to run in a channel
+
+
+# This cleans the whitelist, and then lists the channels.
+def whitelist_list(will):
+    white_list = whitelist_clean(will)
+    response = get_slack_channels(will, white_list)
+    will.reply("Sending you the whitelist as a direct message.")
+    will.say("This is the whitelist: %s" % response, channel=will.message.data.sender.id)
+    return
+
+
+# This removes duplicates from the whitelist,
+# and removes DM channels from the whitelist since they're already whitelisted by default.
+def whitelist_clean(will):
+    white_list = will.load("whitelist")
+    white_list = list(set(white_list))
+    for entry in white_list:
+        if entry.startswith('DB'):
+            white_list.remove(entry)
+    will.save("whitelist", white_list)
+    return white_list
+
+
+# Removes channel(s) from the whitelist returns replies to the channel that it is removed.
+# Requires WILLPlugin object, and optionally a channel name.
+# If no channel names are given it removes the channel the event came from.
+def whitelist_remove(will, channel_name=None):
+    if channel_name:
+        channel_name = channel_name.strip()
+        channel_id = get_slack_chan_ids(will, channel_name.split())
+    else:
+        channel_id = will.message.data.channel.id.split()
+        channel_name = will.message.data.channel.name
+    try:
+        if not channel_id:
+            will.reply('I coulnd\'t find a channel named "%s"' % channel_name)
+        else:
+            white_list = will.load("whitelist")
+            for c_id in channel_id:
+                white_list.remove(c_id)
+            will.save("whitelist", white_list)
+            will.reply('"%s" channel(s) removed from the whitelist.' % channel_name)
+    except Exception as e:
+        print(type(e))
+    return
+
+
+# Adds channel(s) to the whitelist and returns to the channel that it has been added.
+# Requires WILLPlugin object, and optionally a channel name.
+# If no channel names are given it adds the channel the event came from.
+def whitelist_add(will, channel_name=None):
+    if channel_name:
+        channel_name = channel_name.strip()
+        channel_id = get_slack_chan_ids(will, channel_name.split())
+    else:
+        channel_id = will.message.data.channel.id.split()
+        channel_name = will.message.data.channel.name
+    try:
+        if not channel_id:
+            will.reply('I coulnd\'t find a channel named "%s"' % channel_name)
+        else:
+            white_list = will.load("whitelist")
+            for c_id in channel_id:
+                white_list.append(c_id)
+            will.save("whitelist", white_list)
+            will.reply('"%s" channel(s) added to the whitelist.' % channel_name)
+    except Exception as e:
+        print(type(e))
+    return
+
+
+# Returns the channel id the event came in on if that channel is whitelisted.
+# Otherwise it returns the Slack DM channel for that user.
+# Use this with custom plugins so will will respond privately if the room is not whitelisted.
+def wl_chan_id(will):
+    channel = ""
+    try:
+        whitelist = will.load("whitelist")
+        if will.message.data.channel.id not in whitelist:
+            will.reply('The "%s" channel is not whitelisted. So I sent it as a direct message.'
+                       % will.message.data.channel.name.title())
+            channel = will.message.data.sender.id
+        else:
+            channel = will.message.data.channel.id
+    except Exception as e:
+        will.reply("Exception: %s" % type(e))
+    finally:
+        return channel
+
+
+# Returns True or false if the channel the event came in on is in the whitelist
+def wl_check(will):
+    result = False
+    try:
+        whitelist = will.load("whitelist")
+        if will.message.data.channel.id not in whitelist:
+            will.reply('Sorry the "%s" channel is not whitelisted.'
+                       % will.message.data.channel.name.title())
+            result = False
+        else:
+            result = True
+    except Exception as e:
+        will.reply("Exception: %s" % type(e))
+    finally:
+        return result
+
+
+# This looks up the channel ID's in the whitelist and returns the corresponding slack channel name.
+# This is so our channel names are always up to date.
+def get_slack_channels(will, id_list):
+    channel_cache = will.load('slack_channel_cache', {})
+    channel_names = []
+    for k, c in channel_cache.items():
+        for id in id_list:
+            if id in k:
+                channel_names.append(c.name)
+    return channel_names
+
+
+# This looks up the channel names in the whitelist and returns the corresponding slack channel ID.
+# This is so our channel names are always up to date.
+def get_slack_chan_ids(will, channel_names):
+    channel_cache = will.load('slack_channel_cache', {})
+    channel_ids = []
+    for k, c in channel_cache.items():
+        for name in channel_names:
+            if name in c.name:
+                channel_ids.append(k)
+    return channel_ids
+
+
+# This looks up the channel IDs in the whitelist and returns the channel ids that have no members
+# This signifies that a channel has been archived.
+def get_slack_archived_channels(will, id_list):
+    channel_cache = will.load('slack_channel_cache', {})
+    channel_ids = []
+    for k, c in channel_cache.items():
+        for id in id_list:
+            if id in k:
+                if not c.members:
+                    channel_ids.append(c.id)
+    return channel_ids

--- a/will/plugins/slack/__init__.py
+++ b/will/plugins/slack/__init__.py
@@ -1,0 +1,1 @@
+MODULE_DESCRIPTION = "Slack Specific Plugins"

--- a/will/plugins/slack/whitelist.py
+++ b/will/plugins/slack/whitelist.py
@@ -1,0 +1,45 @@
+from will.plugin import WillPlugin
+from will.decorators import hear
+from will.mixins.slackwhitelist import whitelist_remove, whitelist_add, wl_chan_id, whitelist_list, wl_check
+
+
+# This is a group of commands for administering the Slack Channel Whitelist.
+# It defaults to the admin acl group.
+class WhitelistPlugin(WillPlugin):
+
+    # Adds a channel to the whitelist
+    # (?P<channel_name>.*?(?=(?:$)))
+    @hear("(!wladd)(?P<channel>.*?(?=(?:\?)|$))", acl=["admins"])
+    def wl_adder(self, message, channel):
+        if channel:
+            whitelist_add(self, channel_name=channel.strip())
+        else:
+            whitelist_add(self)
+
+    # Removes a channel from the whitelist
+    @hear("(!wlremove)(?P<channel>.*?(?=(?:\?)|$))", acl=["admins"])
+    def wl_remover(self, message, channel):
+        if channel:
+            whitelist_remove(self, channel_name=channel.strip())
+        else:
+            whitelist_remove(self)
+
+    # Sends the current whitelist to the Slack user as a DM
+    @hear("(!whitelist)", acl=["admins"])
+    def whitelist_lister(self, message):
+        whitelist_list(self)
+
+    # Demonstrates how to use the wl_check method to test if a channel is whitelisted.
+    @hear("(!wlcheck)", acl=["admins"])
+    def whitelist_checker(self, message):
+        if wl_check(self):
+            self.reply("This channel is whitelisted!")
+        else:
+            self.reply("This channel is not whitelisted.")
+
+    # Demonstrates how to use the wl_chan_id method to easily add whitelisting to an existing command.
+    @hear("(!wlchan)", acl=["admins"])
+    def whitelist_channel(self, message):
+        # NOTE You need to use self.say for this to work!
+        self.say("This response goes to the channel if it is a whitelisted channel, "
+                 "but goes to a DM if the channel isn't whitelisted.", channel=wl_chan_id(self))


### PR DESCRIPTION
Adds a Mixin for controlling a channel whitelist.
Also adds a slack plugin for administering whitelist through will.

commands:
!wladd <channel names separated by spaces> :
Adds the provided channels to the whitelist. It adds the current channel if no channel is given.
!wlremove <channel names seperated by spaces> :
Removes the provided channels from the whitelist. It removes the current channel if no channel is given.
!whitelist:
Sends the current whitelist to the user as a DM (Note this requires my Slack DM Patch to work.)
!wlcheck
Replies whether the current channel is in the whitelist. This is mostly a demo function to show how to use the whitelist in plugins.
!wlchan
Replies in the channel If the current channel is whitelisted, or sends as a DM if the channel is not whitelisted. This is mostly a demo function to show how to use the whitelist in plugins. (Requires my Slack DM Patch to work)