### PR TITLE
Self.me Responses

### DIFF
--- a/will/backends/io_adapters/slack.py
+++ b/will/backends/io_adapters/slack.py
@@ -195,7 +195,7 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
                 else:
                     logging.critical(
                         "I was asked to post to a slack default channel, but I'm nowhere."
-                        "Please invite me somewhere with '/invite @%s'", self.me.handle
+                        "Please invite me somewhere with '/invite @%s'" % (self.me.name if self.me.name else self.me.handle)
                     )
 
         if event.type in ["topic_change", ]:
@@ -205,7 +205,8 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
             event.data.is_direct and
             event.data.will_said_it is False
         ):
-            event.content = random.choice(UNSURE_REPLIES)
+            self.people  # get the object that contains bot's handle
+            event.content = random.choice(UNSURE_REPLIES) + " Try `@%s help`" % (self.me.name if self.me.name else self.me.handle)
             self.send_message(event)
 
     def handle_request(self, r, data):
@@ -218,7 +219,7 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
 
                 logging.critical(
                     "I was asked to post to the slack %s channel, but I haven't been invited. "
-                    "Please invite me with '/invite @%s'" % (channel.name, self.me.handle)
+                    "Please invite me with '/invite @%s'" % (channel.name, (self.me.name if self.me.name else self.me.handle))
                 )
             else:
                 logging.error("Error sending to slack: %s" % resp_json["error"])


### PR DESCRIPTION
Appended slack-specific response to UNSURE replies. ```Try `@botname help```

Ensured that logging and UNSURE appends uses *self.me.name* when it exists and uses *self.me.handle* as a fallback only.