### PR TITLE
#379 Set will_is_mentioned even if message was direct

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,3 +54,4 @@ mattcl, https://github.com/mattcl
 Ahmed Osman, https://github.com/Ashex 
 Boris Peterbarg, https://github.com/reist
 unicolet, https://github.com/unicolet
+dawn-minion, https://github.com/dawn-minion

--- a/will/backends/io_adapters/hipchat.py
+++ b/will/backends/io_adapters/hipchat.py
@@ -636,11 +636,11 @@ class HipChatBackend(IOBackend, HipChatRosterMixin, HipChatRoomMixin, StorageMix
             if is_private_chat or event["body"].startswith(interpolated_handle):
                 is_direct = True
 
-            if event["body"].startswith(interpolated_handle):
-                event["body"] = event["body"][len(interpolated_handle):].strip()
-
             if interpolated_handle in event["body"]:
                 will_is_mentioned = True
+
+            if event["body"].startswith(interpolated_handle):
+                event["body"] = event["body"][len(interpolated_handle):].strip()
 
             if sender and self.me and sender.id == self.me.id:
                 will_said_it = True

--- a/will/backends/io_adapters/slack.py
+++ b/will/backends/io_adapters/slack.py
@@ -105,14 +105,14 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
             if is_private_chat or event["text"].startswith(interpolated_handle) or event["text"].startswith(real_handle):
                 is_direct = True
 
+            if interpolated_handle in event["text"] or real_handle in event["text"]:
+                will_is_mentioned = True
+
             if event["text"].startswith(interpolated_handle):
                 event["text"] = event["text"][len(interpolated_handle):].strip()
 
             if event["text"].startswith(real_handle):
                 event["text"] = event["text"][len(real_handle):].strip()
-
-            if interpolated_handle in event["text"] or real_handle in event["text"]:
-                will_is_mentioned = True
 
             if event["user"] == self.me.id:
                 will_said_it = True


### PR DESCRIPTION
PR makes it so `will_is_mentioned` is set, even if message was determined to be direct (Began with the Chatbots handle). Change affects only HipChat and Slack, as RocketChat already seems to have this correct behaviour since it checks the mention list. 

Simply moved the `will_is_mentioned` to before where the name is stripped out.

Fixes #379