### PR TITLE
Adds Slack bot message support to Slack backend

### DIFF
--- a/will/backends/io_adapters/slack.py
+++ b/will/backends/io_adapters/slack.py
@@ -55,7 +55,7 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
             ("subtype" not in event or event["subtype"] != "message_changed") and
             # Ignore thread summary events (for now.)
             # TODO: We should stack these into the history.
-            ("subtype" not in event or ("message" in event and "thread_ts" not in event["message"]))
+            ("subtype" not in event or ("message" in event and "thread_ts" not in event["message"]) or event["subtype"] == "bot_message")
         ):
             # print("slack: normalize_incoming_event - %s" % event)
             # Sample of group message
@@ -79,7 +79,19 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
             # u'type': u'message', u'bot_id': u'B5HL9ABFE'},
             # u'type': u'message', u'hidden': True, u'channel': u'D5HGP0YE7'}
 
-            sender = self.people[event["user"]]
+            if event.get("subtype") == "bot_message":
+                bot = self.get_bot(event["bot_id"])
+
+                sender = Person(
+                    id=event["bot_id"],
+                    mention_handle="<@%s>" % event["bot_id"],
+                    name=bot['name'],
+                    handle=bot['name'],
+                    source=event
+                )
+            else:
+                sender = self.people[event["user"]]
+
             channel = clean_for_pickling(self.channels[event["channel"]])
             # print "channel: %s" % channel
             interpolated_handle = "<@%s>" % self.me.id
@@ -114,7 +126,7 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
             if interpolated_handle in event["text"] or real_handle in event["text"]:
                 will_is_mentioned = True
 
-            if event["user"] == self.me.id:
+            if event.get("user") == self.me.id:
                 will_said_it = True
 
             m = Message(
@@ -372,6 +384,33 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
             "channels.join",
             channel=channel_id,
         )
+
+    def get_bot(self, bot_id):
+        # Uses the bots.info Slack method to retrieve info on a bot by ID,
+        # and saves it locally on self._bots. If the bot is already saved,
+        # we return the saved copy.
+        bot = None
+
+        if not hasattr(self, '_bots'):
+            self._bots = {}
+
+        if bot_id in self._bots:
+            bot = self._bots[bot_id]
+        else:
+            bot_api_data = self.client.api_call("bots.info", bot=bot_id)
+
+            if bot_api_data['ok']:
+                self._bots[bot_id] = {
+                    'name': bot_api_data['bot']['name'],
+                    'app_id': bot_api_data['bot']['app_id'],
+                    'id': bot_api_data['bot']['id']
+                }
+
+                bot = self._bots[bot_id]
+            else:
+                logging.error("Failed to find bot with id: {0}".format(bot_id))
+
+        return bot
 
     @property
     def people(self):


### PR DESCRIPTION
PR adds support for Slack bot messages that come in via WebHooks. Based on the work from @Ashex in the original issue, it updates the message type check, and creates a Sender object from the bot details.

Additionally adds a new method in the SlackBackend, get_bot(self, bot_id) that queries the info for the specified bot from Slack. It then creates a new dict object containing the bot information, and stores it under self._bots. If we already have the bot stored, we return the stored object.

Slack does not have a "get all bot info" API call, so, we must get them one at a time like this, unfortunately. The event object received does not contain the bot name, only an ID, hence the inclusion of the above method to get the info.