### PR TITLE
Feature/slack msg attachment

### DIFF
--- a/docs/plugins/reply.md
+++ b/docs/plugins/reply.md
@@ -28,7 +28,7 @@ self.say(content, channel=None, html=False, color="green", notify=False)
 - **`html`**: if the message is HTML. `True` or `False`.
 - **`color`**: (chat room only) the hipchat color to send. "yellow", "red", "green", "purple", "gray", or "random". Default is "green". 
 - **`notify`**: whether the message should trigger a 'ping' notification. `True` or `False`.
-
+- **`attachments`**: A json formated slack attachment. You can build these using the slack_msg_attachment mixin.
 ## Reply with a mention
 
 Sometimes you want will to ping you - that's where @name mentions are great.  To do those in will, you'll want to use `self.reply()`
@@ -51,7 +51,7 @@ self.reply(content, html=False, color="green", notify=False, start_thread=False)
 - **`color`**: (chat room only) the hipchat color to send. "yellow", "red", "green", "purple", "gray", or "random". Default is "green".
 - **`notify`**: whether the message should trigger a 'ping' notification. `True` or `False`.
 - **`start_thread`**: whether Will should start a new thread, if the backend supports it.
-
+- **`attachments`**: A json formated slack attachment. You can build these using the slack_msg_attachment mixin.
 
 
 ## Talk to the room from a webhook

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ for req_file in ["base.txt", "slack.txt", "hipchat.txt", "rocketchat.txt"]:
 
 
 tests_require = [
-    'pytest==2.8.3',
+    'pytest==2.9',
     'pytest-cov',
     'pytest-runner',
     'mock'

--- a/will/mixins/slack_attachment.py
+++ b/will/mixins/slack_attachment.py
@@ -97,7 +97,7 @@ class SlackAttachment:
 
 
 if __name__ == '__main__':
-    """Here's a demo of how to use the slack attachment. First create your attachment object. 
+    """Here's a demo of how to use the slack attachment. First create your attachment object.
     You can fill all the data at initilization."""
     demo_attachment = SlackAttachment(
         fallback="This is incase webcontent doesn't load. Here's the sample content!",
@@ -125,4 +125,3 @@ if __name__ == '__main__':
     for a in attachments:
         demo2_attachment += str(a.slack())
     print("Here's multiple attachments ready to send:\n %s" % demo2_attachment)
-

--- a/will/mixins/slack_attachment.py
+++ b/will/mixins/slack_attachment.py
@@ -1,0 +1,128 @@
+
+
+class SlackAttachment:
+
+    def __init__(self, fallback="", style="default", text="",
+                 button_color=None, action_type="button", button_text="Open Link", button_url=""):
+        """Set your own custom styles here."""
+        self.fallback = fallback
+        self.text = text
+        self.footer = "Default Footer Text"
+        if button_color is None:
+            self.button_color = "#3B80C6"
+        else:
+            self.button_color = button_color
+        if style == "default":
+            self.color = "#555555"
+            self.button_color = "#555555"
+            self.footer_icon = "http://heywill.io/img/favicon.png"
+        if style == "blue":
+            self.color = "#36a64f"
+            self.button_color = "#36a64f"
+            self.footer_icon = "http://heywill.io/img/favicon.png"
+        if style == "green":
+            self.color = "#0e8a16"
+            self.button_color = "#0e8a16"
+            self.footer_icon = "http://heywill.io/img/favicon.png"
+        if style == "purple":
+            self.color = "#876096"
+            self.button_color = "#876096"
+            self.footer_icon = "http://heywill.io/img/favicon.png"
+        if style == "orange":
+            self.color = "#FB7642"
+            self.button_color = "#FB7642"
+            self.footer_icon = "http://heywill.io/img/favicon.png"
+        if style == "yellow":
+            self.color = "#f4c551"
+            self.button_color = "#f4c551"
+            self.footer_icon = "http://heywill.io/img/favicon.png"
+        if style == "teal":
+            self.color = "#007AB8"
+            self.button_color = "#007AB8"
+            self.footer_icon = "http://heywill.io/img/favicon.png"
+        self.action_type = action_type
+        self.button_text = button_text
+        self.button_url = button_url
+        self.actions = [
+            {
+                "color": self.button_color,
+                "type": self.action_type,
+                "text": self.button_text,
+                "url": self.button_url
+            }
+        ]
+
+    def dump(self):
+        print("dump")
+        print(self.fallback)
+        print(self.text)
+        print(self.button_url)
+        pass
+
+    def txt(self):
+        text = " ".join([self.text])
+        return text
+
+    def set_actions(self, text, url):
+        self.button_text = text
+        self.button_url = url
+
+    def add_button(self, text, url=None, button_color=None, button_action_type="button",):
+        if url is None:
+            url = "No URL"
+        if button_color is None:
+            button_color = self.button_color
+
+        self.actions += [
+                {
+                    "color": button_color,
+                    "type": button_action_type,
+                    "text": text,
+                    "url": url
+                }
+            ]
+
+    def slack(self):
+        attachment = [
+                    {
+                        "fallback": self.fallback,
+                        "color": self.color,
+                        "text": self.text,
+                        "actions": self.actions,
+                        "footer": self.footer,
+                        "footer_icon": self.footer_icon,
+                        }
+        ]
+        return attachment
+
+
+if __name__ == '__main__':
+    """Here's a demo of how to use the slack attachment. First create your attachment object. 
+    You can fill all the data at initilization."""
+    demo_attachment = SlackAttachment(
+        fallback="This is incase webcontent doesn't load. Here's the sample content!",
+        text="Here's the sample content!",
+        style="yellow",
+        button_text="Click Me!",
+        button_url="http://heywill.io")
+    """We can add as many buttons as we like after initialization"""
+    demo_attachment.set_actions(text="Go to google!", url="google.com")
+    """You can dump a slack ready json attachment using .slack()"""
+    print("Here's a slack formated json attachment:\n %s" % demo_attachment.slack() + '\n\n')
+    """You can dump plain txt using .txt """
+    print("Here's a txt version of the attachment:\n %s" % demo_attachment.txt() + '\n\n')
+    """Package multiple attachments and append them to a list."""
+    x = ['Ron', 'Bill', 'Gina', 'Rachael']
+    attachments = []
+    for i in x:
+        attachments.append(SlackAttachment(fallback='The name is %s' % i,
+                                           style='yellow',
+                                           text='The name is %s' % i,
+                                           button_text='Open in database',
+                                           button_url='https://my.database.url/people/v2/' + i))
+    """Unpack somewhere else"""
+    demo2_attachment = ""
+    for a in attachments:
+        demo2_attachment += str(a.slack())
+    print("Here's multiple attachments ready to send:\n %s" % demo2_attachment)
+


### PR DESCRIPTION
Adds slack_attachment mixin. This allows you to build nicely formatted slack attachment messages like the ones below.
<img src="https://user-images.githubusercontent.com/3606628/46027591-3af01f80-c0bc-11e8-9051-5671263704a3.jpeg" alt="drawing" width="400"/>
<img src="https://user-images.githubusercontent.com/3606628/46027592-3af01f80-c0bc-11e8-913f-81adad6d199a.jpeg" alt="drawing" width="400"/>

I put this in mixins but I'm not sure that's where it belongs. The styles are in the mixin and should be customized for personal needs so it seemed like putting it in the Slack io backend wasn't a good idea.

I hope this helps!

