### PR TITLE
Do not pass an exception object to `format_exc()`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,3 +54,4 @@ mattcl, https://github.com/mattcl
 Ahmed Osman, https://github.com/Ashex 
 Boris Peterbarg, https://github.com/reist
 unicolet, https://github.com/unicolet
+Rob Salmond, https://github.com/rsalmond

--- a/will/mixins/errors.py
+++ b/will/mixins/errors.py
@@ -17,7 +17,7 @@ class ErrorMixin(object):
         traceback.print_exc()
         error_message = "%s%s" % (
             error_message,
-            ":\n\n%s\nContinuing...\n" % traceback.format_exc(exception_instance)
+            ":\n\n%s\nContinuing...\n" % traceback.format_exc()
         )
         self.add_startup_error(error_message)
         logging.critical(error_message)


### PR DESCRIPTION
Edit, I forgot how to link issues. Fixes #396 

It looks like somewhere along the line passing an exception object to `traceback.format_exc()` began causing problems on python3. Omitting it seems not to hurt anything.

Only outstanding question is should we pull it right out of the `ErrorMixin.startup_error()` method signature and stop passing it along from everywhere `WillBot` collects it.

Also since I checked I'll point out that of the 36 places we call `format_exc()` we don't pass an exception object to any of 'em except this one call.

```
$ cat test.py 
import traceback
try:
    1 / 0
except Exception as e:
    print(traceback.format_exc(e))

$ python2 --version 
Python 2.7.14

$ python2 test.py 
Traceback (most recent call last):
  File "test.py", line 5, in <module>
    1 / 0
ZeroDivisionError: integer division or modulo by zero

$ python3 --version
Python 3.6.3

$ python3 test.py 
Traceback (most recent call last):
  File "test.py", line 5, in <module>
    1 / 0
ZeroDivisionError: division by zero

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 7, in <module>
    print(traceback.format_exc(e))
  File "/usr/lib/python3.6/traceback.py", line 163, in format_exc
    return "".join(format_exception(*sys.exc_info(), limit=limit, chain=chain))
  File "/usr/lib/python3.6/traceback.py", line 117, in format_exception
    type(value), value, tb, limit=limit).format(chain=chain))
  File "/usr/lib/python3.6/traceback.py", line 497, in __init__
    capture_locals=capture_locals)
  File "/usr/lib/python3.6/traceback.py", line 332, in extract
    if limit >= 0:
TypeError: '>=' not supported between instances of 'ZeroDivisionError' and 'int'

$ cat test2.py 
import traceback
try:
    1 / 0
except Exception as e:
    print(traceback.format_exc())

$ python2 test2.py 
Traceback (most recent call last):
  File "test2.py", line 4, in <module>
    1 / 0
ZeroDivisionError: integer division or modulo by zero

$ python3 test2.py 
Traceback (most recent call last):
  File "test2.py", line 4, in <module>
    1 / 0
ZeroDivisionError: division by zero
```