### PR TITLE
eliminate flake8 warnings

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -66,7 +66,7 @@ def deploy_docs():
     local("mv %s/* %s" % (SITE_DIR, tempdir))
 
     current_branch = local("git rev-parse --abbrev-ref HEAD", capture=True)
-    last_commit = local("git log -1 --pretty=\%B", capture=True)
+    last_commit = local(r"git log -1 --pretty=\%B", capture=True)
 
     # Add the new site to build
     local("git checkout gh-pages")

--- a/will/acl.py
+++ b/will/acl.py
@@ -51,8 +51,7 @@ def test_acl(message, acl):
                     "%s was just allowed to perform actions in %s because the backend does not support ACL.  This can be a security risk." % (
                         message.sender.handle,
                         acl,
-                    ) +
-                    "To fix this, set ACL groups in your config.py, or set DISABLE_ACL = True"
+                    ) + "To fix this, set ACL groups in your config.py, or set DISABLE_ACL = True"
                 )
                 return True
     except:

--- a/will/backends/analysis/base.py
+++ b/will/backends/analysis/base.py
@@ -40,7 +40,7 @@ class AnalysisBackend(PubSubMixin, SleepMixin, object):
 
     def do_analyze(self, message):
         # Take message, return a dict to add to its context.
-        raise NotImplemented
+        raise NotImplementedError
 
     def start(self, name, **kwargs):
         signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/will/backends/encryption/base.py
+++ b/will/backends/encryption/base.py
@@ -5,8 +5,8 @@ class WillBaseEncryptionBackend(object):
 
     @staticmethod
     def encrypt_to_b64(raw):
-        raise NotImplemented
+        raise NotImplementedError
 
     @staticmethod
     def decrypt_from_b64(enc):
-        raise NotImplemented
+        raise NotImplementedError

--- a/will/backends/execution/base.py
+++ b/will/backends/execution/base.py
@@ -13,7 +13,7 @@ class ExecutionBackend(object):
     is_will_execution_backend = True
 
     def handle_execution(self, message, context):
-        raise NotImplemented
+        raise NotImplementedError
 
     def no_response(self, message):
         self.bot.pubsub.publish(

--- a/will/backends/generation/base.py
+++ b/will/backends/generation/base.py
@@ -34,7 +34,7 @@ class GenerationBackend(PubSubMixin, SleepMixin, object):
 
     def do_generate(self, message):
         # Take message, return a list of possible responses/matches
-        raise NotImplemented
+        raise NotImplementedError
 
     def start(self, name, **kwargs):
         for k, v in kwargs.items():

--- a/will/backends/generation/fuzzy_all_matches.py
+++ b/will/backends/generation/fuzzy_all_matches.py
@@ -76,15 +76,15 @@ class FuzzyAllMatchesBackend(GenerationBackend):
 
                         # It's not from me, or this search includes me, and
                         and (
-                            message.will_said_it is False or
-                            ("include_me" in l and l["include_me"])
+                            message.will_said_it is False
+                            or ("include_me" in l and l["include_me"])
                         )
 
                         # I'm mentioned, or this is an overheard, or we're in a 1-1
                         and (
-                            message.is_private_chat or
-                            ("direct_mentions_only" not in l or not l["direct_mentions_only"]) or
-                            message.is_direct
+                            message.is_private_chat
+                            or ("direct_mentions_only" not in l or not l["direct_mentions_only"])
+                            or message.is_direct
                         )
                 ):
                     logging.info(" Match (%s) - %s" % (confidence, match_str))

--- a/will/backends/generation/fuzzy_best_match.py
+++ b/will/backends/generation/fuzzy_best_match.py
@@ -72,15 +72,15 @@ class FuzzyBestMatch(GenerationBackend):
 
                         # It's not from me, or this search includes me, and
                         (
-                            message.will_said_it is False or
-                            ("include_me" in l and l["include_me"])
+                            message.will_said_it is False
+                            or ("include_me" in l and l["include_me"])
                         )
 
                         # I'm mentioned, or this is an overheard, or we're in a 1-1
                         and (
-                            message.is_private_chat or
-                            ("direct_mentions_only" not in l or not l["direct_mentions_only"]) or
-                            message.is_direct
+                            message.is_private_chat
+                            or ("direct_mentions_only" not in l or not l["direct_mentions_only"])
+                            or message.is_direct
                         )
                 ):
                     fuzzy_regex = self._generate_compiled_regex(l)

--- a/will/backends/generation/strict_regex.py
+++ b/will/backends/generation/strict_regex.py
@@ -20,15 +20,15 @@ class RegexBackend(GenerationBackend):
 
                     # It's not from me, or this search includes me, and
                     and (
-                        message.will_said_it is False or
-                        ("include_me" in l and l["include_me"])
+                        message.will_said_it is False
+                        or ("include_me" in l and l["include_me"])
                     )
 
                     # I'm mentioned, or this is an overheard, or we're in a 1-1
                     and (
-                        message.is_private_chat or
-                        ("direct_mentions_only" not in l or not l["direct_mentions_only"]) or
-                        message.is_direct
+                        message.is_private_chat
+                        or ("direct_mentions_only" not in l or not l["direct_mentions_only"])
+                        or message.is_direct
                     )
             ):
                 context = Bunch()

--- a/will/backends/io_adapters/base.py
+++ b/will/backends/io_adapters/base.py
@@ -20,7 +20,7 @@ class IOBackend(PubSubMixin, SleepMixin, SettingsMixin, object):
     required_settings = []
 
     def bootstrap(self):
-        raise NotImplemented("""A .bootstrap() method was not provided.
+        raise NotImplementedError("""A .bootstrap() method was not provided.
 
         Bootstrap must provide a way to to have:
         a) self.normalize_incoming_event fired, or incoming events put into self.incoming_queue
@@ -36,7 +36,7 @@ class IOBackend(PubSubMixin, SleepMixin, SettingsMixin, object):
 
     def normalize_incoming_event(self, event):
         # Takes a raw event, converts it into a Message, and returns the normalized Message.
-        raise NotImplemented
+        raise NotImplementedError
 
     def handle_incoming_event(self, event):
         try:
@@ -50,7 +50,7 @@ class IOBackend(PubSubMixin, SleepMixin, SettingsMixin, object):
             ))
 
     def handle_outgoing_event(self, event):
-        raise NotImplemented
+        raise NotImplementedError
 
     def terminate(self):
         pass

--- a/will/backends/io_adapters/hipchat.py
+++ b/will/backends/io_adapters/hipchat.py
@@ -729,9 +729,9 @@ class HipChatBackend(IOBackend, HipChatRosterMixin, HipChatRoomMixin, StorageMix
                     self.send_direct_message(send_source.sender.id, "I can't set the topic of a one-to-one chat.  Let's just talk.", **kwargs)
 
         elif (
-            event.type == "message.no_response" and
-            event.data.is_direct and
-            event.data.will_said_it is False
+            event.type == "message.no_response"
+            and event.data.is_direct
+            and event.data.will_said_it is False
         ):
             if event.data.original_incoming_event.type == "groupchat":
                 self.send_room_message(
@@ -794,7 +794,7 @@ class HipChatBackend(IOBackend, HipChatRosterMixin, HipChatRoomMixin, StorageMix
             self.bridge_thread.terminate()
 
         while (
-            (hasattr(self, "xmpp_thread") and self.xmpp_thread.is_alive()) or
-            (hasattr(self, "bridge_thread") and self.bridge_thread.is_alive())
+            (hasattr(self, "xmpp_thread") and self.xmpp_thread.is_alive())
+            or (hasattr(self, "bridge_thread") and self.bridge_thread.is_alive())
         ):
             time.sleep(0.2)

--- a/will/backends/io_adapters/rocketchat.py
+++ b/will/backends/io_adapters/rocketchat.py
@@ -174,9 +174,9 @@ class RocketChatBackend(IOBackend, StorageMixin):
         if event.type in ["topic_change", ]:
             self.set_topic(event.content)
         elif (
-            event.type == "message.no_response" and
-            event.data.is_direct and
-            event.data.will_said_it is False
+            event.type == "message.no_response"
+            and event.data.is_direct
+            and event.data.will_said_it is False
         ):
             event.content = random.choice(UNSURE_REPLIES)
             self.send_message(event)

--- a/will/backends/io_adapters/slack.py
+++ b/will/backends/io_adapters/slack.py
@@ -50,12 +50,12 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
     def normalize_incoming_event(self, event):
 
         if (
-            "type" in event and
-            event["type"] == "message" and
-            ("subtype" not in event or event["subtype"] != "message_changed") and
+            "type" in event
+            and event["type"] == "message"
+            and ("subtype" not in event or event["subtype"] != "message_changed")
             # Ignore thread summary events (for now.)
             # TODO: We should stack these into the history.
-            ("subtype" not in event or ("message" in event and "thread_ts" not in event["message"]))
+            and ("subtype" not in event or ("message" in event and "thread_ts" not in event["message"]))
         ):
             # print("slack: normalize_incoming_event - %s" % event)
             # Sample of group message
@@ -163,7 +163,7 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
                 event.content = SlackMarkdownConverter().convert(event.content)
 
             event.content = event.content.replace("&", "&amp;")
-            event.content = event.content.replace("\_", "_")
+            event.content = event.content.replace(r"\_", "_")
 
             kwargs = {}
             if "kwargs" in event:
@@ -201,9 +201,9 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
         if event.type in ["topic_change", ]:
             self.set_topic(event)
         elif (
-            event.type == "message.no_response" and
-            event.data.is_direct and
-            event.data.will_said_it is False
+            event.type == "message.no_response"
+            and event.data.is_direct
+            and event.data.will_said_it is False
         ):
             event.content = random.choice(UNSURE_REPLIES)
             self.send_message(event)
@@ -266,9 +266,9 @@ class SlackBackend(IOBackend, SleepMixin, StorageMixin):
                             "thread_ts": event.source_message.original_incoming_event["ts"]
                         })
                     elif (
-                        hasattr(event.source_message, "data") and
-                        hasattr(event.source_message.data, "original_incoming_event") and
-                        "ts" in event.source_message.data.original_incoming_event
+                        hasattr(event.source_message, "data")
+                        and hasattr(event.source_message.data, "original_incoming_event")
+                        and "ts" in event.source_message.data.original_incoming_event
                     ):
                         logging.error(
                             "Hm.  I was told to start a new thread, but while using .say(), instead of .reply().\n"

--- a/will/backends/storage/base.py
+++ b/will/backends/storage/base.py
@@ -29,13 +29,13 @@ class BaseStorageBackend(PrivateBaseStorageBackend):
     """
 
     def do_save(self, key, value, expire=None):
-        raise NotImplemented
+        raise NotImplementedError
 
     def do_load(self, key):
-        raise NotImplemented
+        raise NotImplementedError
 
     def clear(self, key):
-        raise NotImplemented
+        raise NotImplementedError
 
     def clear_all_keys(self):
-        raise NotImplemented
+        raise NotImplementedError

--- a/will/decorators.py
+++ b/will/decorators.py
@@ -1,8 +1,8 @@
 
 def deprecation_warning_for_admin(f):
     err = (
-        "admin_only=True is deprecated and is being used by the `%s` method.\n" % (f.__name__, ) +
-        "  Please use ACLs instead. admin_only will be removed at the end of 2017."
+        """admin_only=True is deprecated and is being used by the `{}` method.\n
+           Please use ACLs instead. admin_only will be removed at the end of 2017.""".format(f.__name__)
     )
     return err
 

--- a/will/main.py
+++ b/will/main.py
@@ -255,23 +255,23 @@ To set your %(name)s:
                     module = import_module(b)
                     for class_name, cls in inspect.getmembers(module, predicate=inspect.isclass):
                         if (
-                            hasattr(cls, "is_will_iobackend") and
-                            cls.is_will_iobackend and
-                            class_name != "IOBackend" and
-                            class_name != "StdInOutIOBackend"
+                            hasattr(cls, "is_will_iobackend")
+                            and cls.is_will_iobackend
+                            and class_name != "IOBackend"
+                            and class_name != "StdInOutIOBackend"
                         ):
                             c = cls()
                             show_valid(c.friendly_name)
                             c.verify_settings()
                             one_valid_backend = True
                             self.valid_io_backends.append(b)
-                except EnvironmentError as e:
+                except EnvironmentError:
                     puts(colored.red("  ✗ %s is missing settings, and will be disabled." % b))
                     puts()
 
                     missing_settings = True
 
-                except Exception as e:
+                except Exception:
                     error_message = (
                         "IO backend %s is missing. Please either remove it \nfrom config.py "
                         "or WILL_IO_BACKENDS, or provide it somehow (pip install, etc)."
@@ -316,7 +316,7 @@ To set your %(name)s:
 
                     one_valid_backend = True
                     show_valid("%s" % b)
-                except ImportError as e:
+                except ImportError:
                     error_message = (
                         "Analysis backend %s is missing. Please either remove it \nfrom config.py "
                         "or WILL_ANALYZE_BACKENDS, or provide it somehow (pip install, etc)."
@@ -359,7 +359,7 @@ To set your %(name)s:
 
                     one_valid_backend = True
                     show_valid("%s" % b)
-                except ImportError as e:
+                except ImportError:
                     error_message = (
                         "Generation backend %s is missing. Please either remove it \nfrom config.py "
                         "or WILL_GENERATION_BACKENDS, or provide it somehow (pip install, etc)."
@@ -402,7 +402,7 @@ To set your %(name)s:
 
                     one_valid_backend = True
                     show_valid("%s" % b)
-                except ImportError as e:
+                except ImportError:
                     error_message = (
                         "Execution backend %s is missing. Please either remove it \nfrom config.py "
                         "or WILL_EXECUTION_BACKENDS, or provide it somehow (pip install, etc)."
@@ -435,14 +435,14 @@ To set your %(name)s:
             for class_name, cls in inspect.getmembers(module, predicate=inspect.isclass):
                 try:
                     if (
-                        hasattr(cls, "is_will_execution_backend") and
-                        cls.is_will_execution_backend and
-                        class_name != "ExecutionBackend"
+                        hasattr(cls, "is_will_execution_backend")
+                        and cls.is_will_execution_backend
+                        and class_name != "ExecutionBackend"
                     ):
                         c = cls(bot=self)
                         self.execution_backends.append(c)
                         show_valid("Execution: %s Backend started." % cls.__name__)
-                except ImportError as e:
+                except ImportError:
                     error_message = (
                         "Execution backend %s is missing. Please either remove it \nfrom config.py "
                         "or WILL_EXECUTION_BACKENDS, or provide it somehow (pip install, etc)."
@@ -551,14 +551,14 @@ To set your %(name)s:
             sys.exit(1)
 
         while (
-            (hasattr(self, "scheduler_thread") and self.scheduler_thread and self.scheduler_thread and self.scheduler_thread.is_alive()) or
-            (hasattr(self, "scheduler_thread") and self.scheduler_thread and self.bottle_thread and self.bottle_thread.is_alive()) or
-            (hasattr(self, "scheduler_thread") and self.scheduler_thread and self.incoming_event_thread and self.incoming_event_thread.is_alive()) or
-            # self.stdin_listener_thread.is_alive() or
-            any([t.is_alive() for t in self.io_threads]) or
-            any([t.is_alive() for t in self.analysis_threads]) or
-            any([t.is_alive() for t in self.generation_threads]) or
-            any([t.is_alive() for t in self.running_execution_threads])
+            (hasattr(self, "scheduler_thread") and self.scheduler_thread and self.scheduler_thread and self.scheduler_thread.is_alive())
+            or (hasattr(self, "scheduler_thread") and self.scheduler_thread and self.bottle_thread and self.bottle_thread.is_alive())
+            or (hasattr(self, "scheduler_thread") and self.scheduler_thread and self.incoming_event_thread and self.incoming_event_thread.is_alive())
+            # or self.stdin_listener_thread.is_alive()
+            or any([t.is_alive() for t in self.io_threads])
+            or any([t.is_alive() for t in self.analysis_threads])
+            or any([t.is_alive() for t in self.generation_threads])
+            or any([t.is_alive() for t in self.running_execution_threads])
             # or
             # ("hipchat" in settings.CHAT_BACKENDS and xmpp_thread and xmpp_thread.is_alive())
         ):
@@ -612,8 +612,7 @@ To set your %(name)s:
                             generation_threads[event.original_incoming_event_hash] = {
                                 "count": 0,
                                 "timeout_end": (
-                                    now +
-                                    datetime.timedelta(seconds=self.generation_timeout / 1000)
+                                    now + datetime.timedelta(seconds=self.generation_timeout / 1000)
                                 ),
                                 "original_incoming_event": q["original_incoming_event"],
                                 "working_event": q["working_event"],
@@ -696,7 +695,7 @@ To set your %(name)s:
             with indent(2):
                 show_valid("Bootstrapped!")
             puts("")
-        except ImportError :
+        except ImportError:
             module_name = traceback.format_exc().split(" ")[-1]
             error("Unable to bootstrap storage - attempting to load %s" % module_name)
             puts(traceback.format_exc())
@@ -716,12 +715,12 @@ To set your %(name)s:
             with indent(2):
                 show_valid("Bootstrapped!")
             puts("")
-        except ImportError as e:
+        except ImportError:
             module_name = traceback.format_exc().split(" ")[-1]
             error("Unable to bootstrap pubsub - attempting to load %s" % module_name)
             puts(traceback.format_exc())
             sys.exit(1)
-        except Exception as e:
+        except Exception:
             error("Unable to bootstrap pubsub!")
             puts(traceback.format_exc())
             sys.exit(1)
@@ -793,10 +792,10 @@ To set your %(name)s:
             for class_name, cls in inspect.getmembers(module, predicate=inspect.isclass):
                 try:
                     if (
-                        hasattr(cls, "is_will_iobackend") and
-                        cls.is_will_iobackend and
-                        class_name != "IOBackend" and
-                        class_name != "StdInOutIOBackend"
+                        hasattr(cls, "is_will_iobackend")
+                        and cls.is_will_iobackend
+                        and class_name != "IOBackend"
+                        and class_name != "StdInOutIOBackend"
                     ):
                         c = cls()
 
@@ -835,9 +834,9 @@ To set your %(name)s:
             for class_name, cls in inspect.getmembers(module, predicate=inspect.isclass):
                 try:
                     if (
-                        hasattr(cls, "is_will_analysisbackend") and
-                        cls.is_will_analysisbackend and
-                        class_name != "AnalysisBackend"
+                        hasattr(cls, "is_will_analysisbackend")
+                        and cls.is_will_analysisbackend
+                        and class_name != "AnalysisBackend"
                     ):
                         c = cls()
                         thread = Process(
@@ -864,9 +863,9 @@ To set your %(name)s:
             for class_name, cls in inspect.getmembers(module, predicate=inspect.isclass):
                 try:
                     if (
-                        hasattr(cls, "is_will_generationbackend") and
-                        cls.is_will_generationbackend and
-                        class_name != "GenerationBackend"
+                        hasattr(cls, "is_will_generationbackend")
+                        and cls.is_will_generationbackend
+                        and class_name != "GenerationBackend"
                     ):
                         c = cls()
                         thread = Process(
@@ -1016,9 +1015,9 @@ To set your %(name)s:
                                                         "setting_name": s,
                                                     }
                                             if (
-                                                "listens_to_messages" in meta and
-                                                meta["listens_to_messages"] and
-                                                "listener_regex" in meta
+                                                "listens_to_messages" in meta
+                                                and meta["listens_to_messages"]
+                                                and "listener_regex" in meta
                                             ):
                                                 # puts("- %s" % function_name)
                                                 regex = meta["listener_regex"]
@@ -1080,7 +1079,7 @@ To set your %(name)s:
                                                 # puts("- %s" % function_name)
                                                 self.bottle_routes.append((plugin_info["class"], function_name))
 
-                                except Exception as e :
+                                except Exception:
                                     error(plugin_name)
                                     self.startup_error(
                                         "Error bootstrapping %s.%s" % (

--- a/will/main.py
+++ b/will/main.py
@@ -1085,7 +1085,7 @@ To set your %(name)s:
                                         "Error bootstrapping %s.%s" % (
                                             plugin_info["class"],
                                             function_name,
-                                        ), e
+                                        )
                                     )
                             if len(plugin_warnings) > 0:
                                 show_invalid(plugin_name)

--- a/will/mixins/hipchat.py
+++ b/will/mixins/hipchat.py
@@ -3,8 +3,8 @@ class HipChatMixin(object):
     def __init__(self, *args, **kwargs):
         import logging
         logging.critical(
-            "HipChatMixin functionality has been moved to the hipchat backend.\n" +
-            "If you need functionality that used to be on this class, please either\n" +
-            "publish messages, or use will.backends.io_backends.hipchat:HipChatBackend."
+            """HipChatMixin functionality has been moved to the hipchat backend.\n
+            If you need functionality that used to be on this class, please either\n
+            publish messages, or use will.backends.io_backends.hipchat:HipChatBackend."""
         )
         super(HipChatMixin, self).__init__(*args, **kwargs)

--- a/will/mixins/naturaltime.py
+++ b/will/mixins/naturaltime.py
@@ -10,7 +10,7 @@ class NaturalTimeMixin(object):
 
     def strip_leading_zeros(self, date_str):
         date_str = date_str.replace(":0", "__&&")
-        date_str = re.sub("0*(\d+)", "\g<1>", date_str)
+        date_str = re.sub(r"0*(\d+)", r"\g<1>", date_str)
         date_str = date_str.replace("__&&", ":0")
         return date_str
 

--- a/will/mixins/room.py
+++ b/will/mixins/room.py
@@ -4,8 +4,8 @@ class Room(object):
     def __init__(self, *args, **kwargs):
         import logging
         logging.critical(
-            "Room has been renamed to HipChatRoom, and will be removed from future releases.\n" +
-            "Please change all your imports to will.backends.io_adapters.hipchat import HipChatRoom"
+            """Room has been renamed to HipChatRoom, and will be removed from future releases.\n
+            Please change all your imports to will.backends.io_adapters.hipchat import HipChatRoom"""
         )
         super(Room, self).__init__(*args, **kwargs)
 
@@ -15,7 +15,7 @@ class RoomMixin(object):
     def __init__(self, *args, **kwargs):
         import logging
         logging.critical(
-            "RoomMixin has been renamed to HipChatRoomMixin, and will be removed from future releases.\n" +
-            "Please change all your imports to will.backends.io_adapters.hipchat import HipChatRoomMixin"
+            """RoomMixin has been renamed to HipChatRoomMixin, and will be removed from future releases.\n
+            Please change all your imports to will.backends.io_adapters.hipchat import HipChatRoomMixin"""
         )
         super(RoomMixin, self).__init__(*args, **kwargs)

--- a/will/mixins/roster.py
+++ b/will/mixins/roster.py
@@ -3,7 +3,7 @@ class RosterMixin(object):
     def __init__(self, *args, **kwargs):
         import logging
         logging.critical(
-            "RosterMixin has been moved to the hipchat backend.\n" +
-            "Please change all your imports to `from will.backends.io_adapters.hipchat import HipChatRosterMixin`"
+            """RosterMixin has been moved to the hipchat backend.\n
+            Please change all your imports to `from will.backends.io_adapters.hipchat import HipChatRosterMixin`"""
         )
         super(RosterMixin, self).__init__(*args, **kwargs)

--- a/will/mixins/schedule.py
+++ b/will/mixins/schedule.py
@@ -57,8 +57,8 @@ class ScheduleMixin(PubSubMixin, object):
     def add_to_schedule(self, when, item, periodic_list=False, ignore_scheduler_lock=False):
         try:
             while (
-                (ignore_scheduler_lock is False and self.load("scheduler_lock", False)) or
-                self.load("scheduler_add_lock", False)
+                (ignore_scheduler_lock is False and self.load("scheduler_lock", False))
+                or self.load("scheduler_add_lock", False)
             ):
                 import sys
                 sys.stdout.write("waiting for lock to clear\n")

--- a/will/plugin.py
+++ b/will/plugin.py
@@ -112,16 +112,16 @@ class WillPlugin(EmailMixin, StorageMixin, NaturalTimeMixin, HipChatRoomMixin, H
         # Be really smart about what we're getting back.
         if (
             (
-                (event and hasattr(event, "will_internal_type") and event.will_internal_type == "Message") or
-                (event and hasattr(event, "will_internal_type") and event.will_internal_type == "Event")
+                (event and hasattr(event, "will_internal_type") and event.will_internal_type == "Message")
+                or (event and hasattr(event, "will_internal_type") and event.will_internal_type == "Event")
             ) and type(content) == type("words")
         ):
             # "1.x world - user passed a message and a string.  Keep rolling."
             pass
         elif (
                 (
-                    (content and hasattr(content, "will_internal_type") and content.will_internal_type == "Message") or
-                    (content and hasattr(content, "will_internal_type") and content.will_internal_type == "Event")
+                    (content and hasattr(content, "will_internal_type") and content.will_internal_type == "Message")
+                    or (content and hasattr(content, "will_internal_type") and content.will_internal_type == "Event")
                 ) and type(event) == type("words")
         ):
             # "User passed the string and message object backwards, and we're in a 1.x world"
@@ -130,8 +130,8 @@ class WillPlugin(EmailMixin, StorageMixin, NaturalTimeMixin, HipChatRoomMixin, H
             event = temp_content
             del temp_content
         elif (
-            type(event) == type("words") and
-            not content
+            type(event) == type("words")
+            and not content
         ):
             # "We're in the Will 2.0 automagic event finding."
             content = event

--- a/will/plugins/chat_room/rooms.py
+++ b/will/plugins/chat_room/rooms.py
@@ -4,7 +4,7 @@ from will.decorators import respond_to, periodic, hear, randomly, route, rendere
 
 class RoomsPlugin(WillPlugin):
 
-    @respond_to("what are the rooms\?")
+    @respond_to(r"what are the rooms\?")
     def list_rooms(self, message):
         """what are the rooms?: List all the rooms I know about."""
         context = {"rooms": self.available_rooms.values(), }
@@ -15,7 +15,7 @@ class RoomsPlugin(WillPlugin):
         self.update_available_rooms()
         self.say("Done!", message=message)
 
-    @respond_to("who is in this room\?")
+    @respond_to(r"who is in this room\?")
     def participants_in_room(self, message):
         """who is in this room?: List all the participants of this room."""
         room = self.get_room_from_message(message)

--- a/will/plugins/devops/pagerduty.py
+++ b/will/plugins/devops/pagerduty.py
@@ -125,7 +125,7 @@ class PagerDutyPlugin(WillPlugin):
         self._update_incident(message, None, 'resolve_all')
 
     @require_settings("PAGERDUTY_SUBDOMAIN", "PAGERDUTY_API_KEY")
-    @respond_to("^pd maintenance (?P<service_name>[\S+ ]+) (?P<interval>[1-9])h$")
+    @respond_to(r"^pd maintenance (?P<service_name>[\S+ ]+) (?P<interval>[1-9])h$")
     def set_service_maintenance(self, message, service_name=None, interval=None):
         if not interval:
             interval = 1

--- a/will/plugins/friendly/howareyou.py
+++ b/will/plugins/friendly/howareyou.py
@@ -15,7 +15,7 @@ RESPONSES = [
 
 class HowAreYouPlugin(WillPlugin):
 
-    @hear("^how are you\?")
+    @hear(r"^how are you\?")
     def how_are_you(self, message):
         now = datetime.datetime.now()
         context = {

--- a/will/plugins/fun/wordgame.py
+++ b/will/plugins/fun/wordgame.py
@@ -204,7 +204,7 @@ WORD_GAME_TOPICS = [
 
 class WordGamePlugin(WillPlugin):
 
-    @respond_to("^(play a word game|scattegories)(\!\.)?$")
+    @respond_to(r"^(play a word game|scattegories)(\!\.)?$")
     def word_game_round(self, message):
         "play a word game: Play a game where you think of words that start with a letter and fit a topic."
 

--- a/will/plugins/productivity/images.py
+++ b/will/plugins/productivity/images.py
@@ -13,8 +13,8 @@ class ImagesPlugin(WillPlugin):
         """image me ___ : Search google images for ___, and post a random one."""
 
         if (
-                getattr(settings, "GOOGLE_API_KEY", False) and
-                getattr(settings, "GOOGLE_CUSTOM_SEARCH_ENGINE_ID", False)
+                getattr(settings, "GOOGLE_API_KEY", False)
+                and getattr(settings, "GOOGLE_CUSTOM_SEARCH_ENGINE_ID", False)
         ):
             self.say(
                 "Sorry, I'm missing my GOOGLE_API_KEY and GOOGLE_CUSTOM_SEARCH_ENGINE_ID."
@@ -63,8 +63,8 @@ class ImagesPlugin(WillPlugin):
     def gif_me(self, message, search_query):
 
         if (
-                getattr(settings, "GOOGLE_API_KEY", False) and
-                getattr(settings, "GOOGLE_CUSTOM_SEARCH_ENGINE_ID", False)
+                getattr(settings, "GOOGLE_API_KEY", False)
+                and getattr(settings, "GOOGLE_CUSTOM_SEARCH_ENGINE_ID", False)
         ):
             self.say(
                 "Sorry, I'm missing my GOOGLE_API_KEY and GOOGLE_CUSTOM_SEARCH_ENGINE_ID."

--- a/will/plugins/productivity/remind.py
+++ b/will/plugins/productivity/remind.py
@@ -4,7 +4,7 @@ from will.decorators import respond_to, periodic, hear, randomly, route, rendere
 
 class RemindPlugin(WillPlugin):
 
-    @respond_to("(?:can |will you )?remind me(?P<to_string> to)? (?P<reminder_text>.*?) (at|on|in) (?P<remind_time>.*)?\??")
+    @respond_to(r"(?:can |will you )?remind me(?P<to_string> to)? (?P<reminder_text>.*?) (at|on|in) (?P<remind_time>.*)?\??")
     def remind_me_at(self, message, reminder_text=None, remind_time=None, to_string=""):
         """remind me to ___ at ___: Set a reminder for a thing, at a time."""
         parsed_time = self.parse_natural_time(remind_time)
@@ -22,7 +22,7 @@ class RemindPlugin(WillPlugin):
         self.schedule_say(formatted_reminder_text, parsed_time, message=message, notify=True)
         self.say("%(reminder_text)s %(natural_datetime)s. Got it." % locals(), message=message)
 
-    @respond_to("(?:can|will you )?remind (?P<reminder_recipient>(?!me).*?)(?P<to_string> to>) ?(?P<reminder_text>.*?) (at|on|in) (?P<remind_time>.*)?\??")
+    @respond_to(r"(?:can|will you )?remind (?P<reminder_recipient>(?!me).*?)(?P<to_string> to>) ?(?P<reminder_text>.*?) (at|on|in) (?P<remind_time>.*)?\??")
     def remind_somebody_at(self, message, reminder_recipient=None, reminder_text=None, remind_time=None, to_string=""):
         """remind ___ to ___ at ___: Set a reminder for a thing, at a time for somebody else."""
         parsed_time = self.parse_natural_time(remind_time)

--- a/will/plugins/productivity/world_time.py
+++ b/will/plugins/productivity/world_time.py
@@ -56,7 +56,7 @@ def get_timezone(lat, lng):
 
 class TimePlugin(WillPlugin):
 
-    @respond_to("what time is it in (?P<place>.*)?\?+")
+    @respond_to(r"what time is it in (?P<place>.*)?\?+")
     def what_time_is_it_in(self, message, place):
         """what time is it in ___: Say the time in almost any city on earth."""
         location = get_location(place)
@@ -71,7 +71,7 @@ class TimePlugin(WillPlugin):
         else:
             self.say("I couldn't find anywhere named %(place)s." % {'place': location.name}, message=message)
 
-    @respond_to("what time is it(\?)?$", multiline=False)
+    @respond_to(r"what time is it(\?)?$", multiline=False)
     def what_time_is_it(self, message):
         """what time is it: Say the time where I am."""
         now = datetime.datetime.now()

--- a/will/settings.py
+++ b/will/settings.py
@@ -205,9 +205,11 @@ IO_BACKENDS = "
         # Set for hipchat
         for b in settings["IO_BACKENDS"]:
             if "hipchat" in b:
-                if "ALLOW_INSECURE_HIPCHAT_SERVER" in settings and\
-                        (settings["ALLOW_INSECURE_HIPCHAT_SERVER"] is True or
-                         settings["ALLOW_INSECURE_HIPCHAT_SERVER"].lower() == "true"):
+                if "ALLOW_INSECURE_HIPCHAT_SERVER" in settings \
+                        and (
+                        settings["ALLOW_INSECURE_HIPCHAT_SERVER"] is True
+                        or settings["ALLOW_INSECURE_HIPCHAT_SERVER"].lower() == "true"
+                        ):
                     warn("You are choosing to run will with SSL disabled. "
                          "This is INSECURE and should NEVER be deployed outside a development environment.")
                     settings["ALLOW_INSECURE_HIPCHAT_SERVER"] = True
@@ -224,8 +226,8 @@ IO_BACKENDS = "
                         settings["HIPCHAT_ROOMS"] = None
 
                 if (
-                    "HIPCHAT_DEFAULT_ROOM" not in settings and "HIPCHAT_ROOMS" in settings and
-                    settings["HIPCHAT_ROOMS"] and len(settings["HIPCHAT_ROOMS"]) > 0
+                    "HIPCHAT_DEFAULT_ROOM" not in settings and "HIPCHAT_ROOMS" in settings
+                    and settings["HIPCHAT_ROOMS"] and len(settings["HIPCHAT_ROOMS"]) > 0
                 ):
                     if not quiet:
                         warn("no HIPCHAT_DEFAULT_ROOM found in the environment or config.  "
@@ -235,16 +237,16 @@ IO_BACKENDS = "
             if "HIPCHAT_HANDLE" in settings and "HIPCHAT_HANDLE_NOTED" not in settings:
                 if not quiet:
                     note(
-                        "HIPCHAT_HANDLE is no longer required (or used), as Will knows how to get\n" +
-                        "        his current handle from the HipChat servers."
+                        """HIPCHAT_HANDLE is no longer required (or used), as Will knows how to get\n
+                                his current handle from the HipChat servers."""
                     )
                     settings["HIPCHAT_HANDLE_NOTED"] = True
 
             if "HIPCHAT_NAME" in settings and "HIPCHAT_NAME_NOTED" not in settings:
                 if not quiet:
                     note(
-                        "HIPCHAT_NAME is no longer required (or used), as Will knows how to get\n" +
-                        "        his current name from the HipChat servers."
+                        """HIPCHAT_NAME is no longer required (or used), as Will knows how to get\n
+                                his current name from the HipChat servers."""
                     )
                     settings["HIPCHAT_NAME_NOTED"] = True
 
@@ -258,8 +260,8 @@ IO_BACKENDS = "
                         settings["ROCKETCHAT_URL"] = settings["ROCKETCHAT_URL"][:-1]
 
         if (
-            "DEFAULT_BACKEND" not in settings and "IO_BACKENDS" in settings and
-            settings["IO_BACKENDS"] and len(settings["IO_BACKENDS"]) > 0
+            "DEFAULT_BACKEND" not in settings and "IO_BACKENDS" in settings
+            and settings["IO_BACKENDS"] and len(settings["IO_BACKENDS"]) > 0
         ):
             if not quiet:
                 note("no DEFAULT_BACKEND found in the environment or config.\n  "
@@ -403,17 +405,17 @@ IO_BACKENDS = "
                     key = auto_key()
                     if key:
                         warn(
-                            "No SECRET_KEY specified and ENABLE_INTERNAL_ENCRYPTION is on.\n" +
-                            "  Temporarily auto-generating a key specific to this computer:\n    %s\n" % (key,) +
-                            "  Please set WILL_SECRET_KEY in the environment as soon as possible to ensure \n" +
-                            "  Will is able to access information from previous runs."
+                            """No SECRET_KEY specified and ENABLE_INTERNAL_ENCRYPTION is on.\n
+                               Temporarily auto-generating a key specific to this computer:\n    {}\n
+                               Please set WILL_SECRET_KEY in the environment as soon as possible to ensure \n
+                               Will is able to access information from previous runs.""".format(key)
                         )
                     else:
                         error(
-                            "ENABLE_INTERNAL_ENCRYPTION is turned on, but a SECRET_KEY has not been given.\n" +
-                            "We tried to automatically generate temporary SECRET_KEY, but this appears to be a \n" +
-                            "shared or virtualized environment.\n Please set a unique secret key in the " +
-                            "environment as WILL_SECRET_KEY to run will."
+                            """ENABLE_INTERNAL_ENCRYPTION is turned on, but a SECRET_KEY has not been given.\n
+                               We tried to automatically generate temporary SECRET_KEY, but this appears to be a \n"
+                               shared or virtualized environment.\n Please set a unique secret key in the
+                               environment as WILL_SECRET_KEY to run will."""
                         )
                         print("  Unable to start will without a SECRET_KEY while encryption is turned on. Shutting down.")
                         sys.exit(1)

--- a/will/storage/couchbase_storage.py
+++ b/will/storage/couchbase_storage.py
@@ -2,6 +2,6 @@ from will.utils import warn
 from will.backends.storage.couchbase_backend import CouchbaseStorage
 
 warn(
-    "Deprecation - will.storage.couchbase_storage has been moved to will.backends.storage.couchbase_backend, " +
-    "and will be removed in version 2.2.  Please update your paths accordingly!"
+    """Deprecation - will.storage.couchbase_storage has been moved to will.backends.storage.couchbase_backend,
+     and will be removed in version 2.2.  Please update your paths accordingly!"""
 )

--- a/will/storage/file_storage.py
+++ b/will/storage/file_storage.py
@@ -2,6 +2,6 @@ from will.utils import warn
 from will.backends.storage.file_backend import FileStorage
 
 warn(
-    "Deprecation - will.storage.file_storage has been moved to will.backends.storage.file_backend, " +
-    "and will be removed in version 2.2.  Please update your paths accordingly!"
+    """Deprecation - will.storage.file_storage has been moved to will.backends.storage.file_backend,
+     and will be removed in version 2.2.  Please update your paths accordingly!"""
 )

--- a/will/storage/redis_storage.py
+++ b/will/storage/redis_storage.py
@@ -2,6 +2,6 @@ from will.utils import warn
 from will.backends.storage.redis_backend import RedisStorage
 
 warn(
-    "Deprecation - will.storage.redis_storage has been moved to will.backends.storage.redis_backend, " +
-    "and will be removed in version 2.2.  Please update your paths accordingly!"
+    """Deprecation - will.storage.redis_storage has been moved to will.backends.storage.redis_backend,
+     and will be removed in version 2.2.  Please update your paths accordingly!"""
 )

--- a/will/utils.py
+++ b/will/utils.py
@@ -99,7 +99,7 @@ def note(warn_string):
 
 
 def print_head():
-        puts("""
+        puts(r"""
       ___/-\___
   ___|_________|___
      |         |


### PR DESCRIPTION
Started looking at brushing up the test suite, got distracted doing this.

This basically amounts to:
 * Formatting conventions for where to put multi line boolean operators.
 * Using raw strings for regexes which could cause unicode problems
 * Discarding unused variables (exceptions, see #397)
 * s/NotImplemented/NotImplementedError/
 * Tidying up multi line strings.

Tested in interactive shell and running with slack backend, no obvious issues.

**Before:**
```
$ git checkout master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
$ flake8
./fabfile.py:69:26: W605 invalid escape sequence '\%'
./will/decorators.py:4:9: W504 line break after binary operator
./will/settings.py:209:26: W504 line break after binary operator
./will/settings.py:227:21: W504 line break after binary operator
./will/settings.py:238:25: W504 line break after binary operator
./will/settings.py:246:25: W504 line break after binary operator
./will/settings.py:261:13: W504 line break after binary operator
./will/settings.py:406:29: W504 line break after binary operator
./will/settings.py:407:29: W504 line break after binary operator
./will/settings.py:408:29: W504 line break after binary operator
./will/settings.py:413:29: W504 line break after binary operator
./will/settings.py:414:29: W504 line break after binary operator
./will/settings.py:415:29: W504 line break after binary operator
./will/utils.py:113:-150: W605 invalid escape sequence '\_'
./will/utils.py:113:-49: W605 invalid escape sequence '\_'
./will/acl.py:54:21: W504 line break after binary operator
./will/main.py:258:29: W504 line break after binary operator
./will/main.py:259:29: W504 line break after binary operator
./will/main.py:260:29: W504 line break after binary operator
./will/main.py:274:37: F841 local variable 'e' is assigned to but never used
./will/main.py:319:39: F841 local variable 'e' is assigned to but never used
./will/main.py:362:39: F841 local variable 'e' is assigned to but never used
./will/main.py:405:39: F841 local variable 'e' is assigned to but never used
./will/main.py:438:25: W504 line break after binary operator
./will/main.py:439:25: W504 line break after binary operator
./will/main.py:445:39: F841 local variable 'e' is assigned to but never used
./will/main.py:554:13: W504 line break after binary operator
./will/main.py:555:13: W504 line break after binary operator
./will/main.py:557:13: W504 line break after binary operator
./will/main.py:558:13: W504 line break after binary operator
./will/main.py:559:13: W504 line break after binary operator
./will/main.py:560:13: W504 line break after binary operator
./will/main.py:615:37: W504 line break after binary operator
./will/main.py:699:27: E203 whitespace before ':'
./will/main.py:724:29: F841 local variable 'e' is assigned to but never used
./will/main.py:796:25: W504 line break after binary operator
./will/main.py:797:25: W504 line break after binary operator
./will/main.py:798:25: W504 line break after binary operator
./will/main.py:838:25: W504 line break after binary operator
./will/main.py:839:25: W504 line break after binary operator
./will/main.py:867:25: W504 line break after binary operator
./will/main.py:868:25: W504 line break after binary operator
./will/main.py:1019:49: W504 line break after binary operator
./will/main.py:1020:49: W504 line break after binary operator
./will/main.py:1083:54: E203 whitespace before ':'
./will/plugin.py:115:17: W504 line break after binary operator
./will/plugin.py:123:21: W504 line break after binary operator
./will/plugin.py:133:13: W504 line break after binary operator
./will/storage/file_storage.py:5:5: W504 line break after binary operator
./will/storage/couchbase_storage.py:5:5: W504 line break after binary operator
./will/storage/redis_storage.py:5:5: W504 line break after binary operator
./will/plugins/productivity/remind.py:7:108: W605 invalid escape sequence '\?'
./will/plugins/productivity/remind.py:25:139: W605 invalid escape sequence '\?'
./will/plugins/productivity/world_time.py:59:39: W605 invalid escape sequence '\?'
./will/plugins/productivity/world_time.py:74:22: W605 invalid escape sequence '\?'
./will/plugins/productivity/images.py:16:17: W504 line break after binary operator
./will/plugins/productivity/images.py:66:17: W504 line break after binary operator
./will/plugins/friendly/howareyou.py:18:18: W605 invalid escape sequence '\?'
./will/plugins/chat_room/rooms.py:7:24: W605 invalid escape sequence '\?'
./will/plugins/chat_room/rooms.py:18:25: W605 invalid escape sequence '\?'
./will/plugins/fun/wordgame.py:207:39: W605 invalid escape sequence '\!'
./will/plugins/fun/wordgame.py:207:41: W605 invalid escape sequence '\.'
./will/plugins/devops/pagerduty.py:128:40: W605 invalid escape sequence '\S'
./will/backends/storage/base.py:32:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./will/backends/storage/base.py:35:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./will/backends/storage/base.py:38:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./will/backends/storage/base.py:41:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./will/backends/io_adapters/slack.py:53:13: W504 line break after binary operator
./will/backends/io_adapters/slack.py:54:13: W504 line break after binary operator
./will/backends/io_adapters/slack.py:57:13: W504 line break after binary operator
./will/backends/io_adapters/slack.py:166:14: W605 invalid escape sequence '\_'
./will/backends/io_adapters/slack.py:204:13: W504 line break after binary operator
./will/backends/io_adapters/slack.py:205:13: W504 line break after binary operator
./will/backends/io_adapters/slack.py:269:25: W504 line break after binary operator
./will/backends/io_adapters/slack.py:270:25: W504 line break after binary operator
./will/backends/io_adapters/rocketchat.py:177:13: W504 line break after binary operator
./will/backends/io_adapters/rocketchat.py:178:13: W504 line break after binary operator
./will/backends/io_adapters/hipchat.py:732:13: W504 line break after binary operator
./will/backends/io_adapters/hipchat.py:733:13: W504 line break after binary operator
./will/backends/io_adapters/hipchat.py:797:13: W504 line break after binary operator
./will/backends/io_adapters/base.py:23:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./will/backends/io_adapters/base.py:39:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./will/backends/io_adapters/base.py:53:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./will/backends/encryption/base.py:8:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./will/backends/encryption/base.py:12:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./will/backends/execution/base.py:16:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./will/backends/analysis/base.py:43:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./will/backends/generation/strict_regex.py:23:25: W504 line break after binary operator
./will/backends/generation/strict_regex.py:29:25: W504 line break after binary operator
./will/backends/generation/strict_regex.py:30:25: W504 line break after binary operator
./will/backends/generation/fuzzy_best_match.py:75:29: W504 line break after binary operator
./will/backends/generation/fuzzy_best_match.py:81:29: W504 line break after binary operator
./will/backends/generation/fuzzy_best_match.py:82:29: W504 line break after binary operator
./will/backends/generation/fuzzy_all_matches.py:79:29: W504 line break after binary operator
./will/backends/generation/fuzzy_all_matches.py:85:29: W504 line break after binary operator
./will/backends/generation/fuzzy_all_matches.py:86:29: W504 line break after binary operator
./will/backends/generation/base.py:37:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./will/mixins/naturaltime.py:13:10: W605 invalid escape sequence '\g'
./will/mixins/naturaltime.py:13:13: W605 invalid escape sequence '\d'
./will/mixins/roster.py:6:13: W504 line break after binary operator
./will/mixins/hipchat.py:6:13: W504 line break after binary operator
./will/mixins/hipchat.py:7:13: W504 line break after binary operator
./will/mixins/schedule.py:60:17: W504 line break after binary operator
./will/mixins/room.py:7:13: W504 line break after binary operator
./will/mixins/room.py:18:13: W504 line break after binary operator
```

**After:**
```
$ git checkout pep8
Switched to branch 'pep8'
$ flake8
$ 
```