### PR TITLE
unpin pytest version w. broken dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 addopts = --cov-report term-missing --cov-config=.coveragerc --cov .
 
 [aliases]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ for req_file in ["base.txt", "slack.txt", "hipchat.txt", "rocketchat.txt"]:
 
 
 tests_require = [
-    'pytest==2.9.1',
+    'pytest',
     'pytest-cov',
     'pytest-runner',
     'mock'


### PR DESCRIPTION
ATM pytest-cov is unpinned while pytest is, causing this issue.

```
pkg_resources.ContextualVersionConflict: (pytest 2.9.1 (/home/travis/build/skoczen/will/.eggs/pytest-2.9.1-py2.7.egg), Requirement.parse('pytest>=3.6'), set(['pytest-cov']))
```

Assuming Travis doesn't fail the way #398 did, this should fix it.