### PR TITLE
Tox support for py3, flake8 cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
+dist: xenial
 language: python
 python:
   - "2.7"
   - "3.5"
   - "3.6"
-dist: xenial
-language: python
-python: 3.7
+  - "3.7"
 sudo: false
 services:
     - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+dist: xenial
+language: python
+python: 3.7
 sudo: false
 services:
     - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "3.7"
 sudo: false
 services:
     - docker
@@ -11,7 +10,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y libffi-dev libxml2-dev
 install:
-- pip install -U tox
+- pip install tox-travis
 - pip install -r will/requirements/dev.txt
 script:
 - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: python
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 sudo: false
 services:
     - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: xenial
 language: python
 python:
   - "2.7"
+  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, flake8
+envlist = py27, py34, py35, py36, py37, flake8
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, flake8
+envlist = py27, py34, py35, py36, py37
 
 
 [testenv]
@@ -9,7 +9,4 @@ deps =
     -rrequirements.txt
 commands = 
     python setup.py test
-
-[testenv:flake8]
-commands =
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,5 @@ commands =
     python setup.py test
 
 [testenv:flake8]
-basepython = python3
 commands =
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,16 @@
 [tox]
-envlist = py27, 35, flake8
+envlist = py27, py35, py36, py37, flake8
 
 
 [testenv]
-commands = 
-    python setup.py test
 deps =
     flake8
     sleekxmpp==1.3.2
     -rrequirements.txt
+commands = 
+    python setup.py test
 
 [testenv:flake8]
+basepython = python3
 commands =
     flake8

--- a/will/backends/io_adapters/hipchat.py
+++ b/will/backends/io_adapters/hipchat.py
@@ -285,7 +285,7 @@ class HipChatXMPPClient(ClientXMPP, HipChatRosterMixin, HipChatRoomMixin, Storag
         else:
             for name, r in self.available_rooms.items():
                 if not hasattr(self, "default_room"):
-                        self.default_room = r
+                    self.default_room = r
                 self.rooms.append(r)
 
         self.nick = settings.HIPCHAT_HANDLE

--- a/will/main.py
+++ b/will/main.py
@@ -36,7 +36,7 @@ from will.utils import show_valid, show_invalid, error, warn, note, print_head, 
 
 # Force UTF8
 if sys.version_info < (3, 0):
-    reload(sys)  # flake8: noqa
+    reload(sys)  # noqa
     sys.setdefaultencoding('utf8')
 else:
     raw_input = input
@@ -562,9 +562,9 @@ To set your %(name)s:
             # or
             # ("hipchat" in settings.CHAT_BACKENDS and xmpp_thread and xmpp_thread.is_alive())
         ):
-                sys.stdout.write(".")
-                sys.stdout.flush()
-                time.sleep(0.5)
+            sys.stdout.write(".")
+            sys.stdout.flush()
+            time.sleep(0.5)
         print(". done.\n")
         sys.exit(1)
 

--- a/will/requirements/base.txt
+++ b/will/requirements/base.txt
@@ -19,10 +19,10 @@ pyasn1==0.1.7
 pycrypto==2.6.1
 pygerduty==0.28
 pytz==2017.2
-PyYAML==3.10
+PyYAML==3.13
 regex==2017.9.23
 redis==2.10.6
-requests==2.18.4
+requests==2.20.0
 six==1.10.0
 urllib3[secure]
 websocket-client==0.44.0

--- a/will/utils.py
+++ b/will/utils.py
@@ -99,7 +99,7 @@ def note(warn_string):
 
 
 def print_head():
-        puts(r"""
+    puts(r"""
       ___/-\___
   ___|_________|___
      |         |


### PR DESCRIPTION
- Add py35, py36, py37 envlist in tox.ini

- Fix flake8 errors
```
./will/utils.py:102:9:` E117 over-indented
./will/main.py:39:5: F821 undefined name 'reload'
./will/main.py:565:17: E117 over-indented
./will/backends/io_adapters/hipchat.py:288:25: E117 over-indented
```
- Bump version of PyYAML to 3.13 and requests to 2.20.0 to support py37.
- Make tests pass in travis

Result:

```
_________________________________________________________________________________________________ summary __________________________________________________________________________________________________
  py27: commands succeeded
  py35: commands succeeded
  py36: commands succeeded
  py37: commands succeeded
  flake8: commands succeeded
  congratulations :)
```