### PR TITLE
do ACL checks by id rather than handle

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -50,6 +50,7 @@ Config.py is where all of your non-sensitive settings should go.   This includes
 - `ALLOW_INSECURE_HIPCHAT_SERVER`: the option to disable SSL checks (seriously, don't),
 - `ENABLE_INTERNAL_ENCRYPTION`: the option to turn off internal encryption (not recommended, but you can do it.)
 - `PROXY_URL`: Proxy server to use, consider exporting it as `WILL_PROXY_URL` environment variable, if it contains sensitive information
+- `ACL`: Define arbitrary groups of users which can be used to restrict access to certain Will commands. See [access control](plugins/builtins/#access-control) for details.
 - and all of your non-sensitive plugin settings.
 
 

--- a/docs/plugins/builtins.md
+++ b/docs/plugins/builtins.md
@@ -132,7 +132,7 @@ and then clicking your @name next to the `user` field.
 In rocketchat the user ID can by found by visiting the URI /account/tokens on your instance and generating a new (temporary) personal access token, the
 user ID will be presented with the new token, which can then be deleted.
 
-__NOTE__: As Hipchat is end-of-life it is not supported and will be removed completely from Will in an upcoming release.
+__NOTE__: As hipchat is end-of-life it is not supported and will be removed completely from Will in an upcoming release.
 
 ## Access settings and config
 

--- a/docs/plugins/builtins.md
+++ b/docs/plugins/builtins.md
@@ -132,6 +132,8 @@ and then clicking your @name next to the `user` field.
 In rocketchat the user ID can by found by visiting the URI /account/tokens on your instance and generating a new (temporary) personal access token, the
 user ID will be presented with the new token, which can then be deleted.
 
+__NOTE__: As Hipchat is end-of-life it is not supported and will be removed completely from Will in an upcoming release.
+
 ## Access settings and config
 
 Will takes care of passing in environment variables and config via the `settings` module.  To use it:

--- a/docs/plugins/builtins.md
+++ b/docs/plugins/builtins.md
@@ -97,8 +97,13 @@ Here's an example with an ops team, and an admin team:
 # config.py
 
 ACL = {
-    "ops": ["steven", "levi", "susan"],
-    "admins": ["wooh"],
+    "ops": ["U2A06UQHX", #steven
+            "UXHQU60A2", #levi
+            "UABC1234",  #susan
+    ],
+    "admins": [
+            "UDEF5678",  #wooh
+    ],
 }
 ```
 
@@ -119,6 +124,13 @@ def terminate_ec2_instance(self, message, instance_id):
 
 Complex ACL behaviors, simple as that.
 
+### Determinig User ID's
+
+In slack the user ID can be found by visiting [this link](https://api.slack.com/methods/users.info/test), selecting your slack account from the dropdown,
+and then clicking your @name next to the `user` field.
+
+In rocketchat the user ID can by found by visiting the URI /account/tokens on your instance and generating a new (temporary) personal access token, the
+user ID will be presented with the new token, which can then be deleted.
 
 ## Access settings and config
 

--- a/will/acl.py
+++ b/will/acl.py
@@ -20,7 +20,7 @@ def get_acl_members(acl):
     return acl_members
 
 
-def is_acl_allowed(nick, acl):
+def is_acl_allowed(nick, id, acl):
     if not getattr(settings, "ACL", None):
         logging.warning(
             "%s was just allowed to perform actions in %s because no ACL settings exist. This can be a security risk." % (
@@ -31,7 +31,7 @@ def is_acl_allowed(nick, acl):
         return True
     for a in acl:
         acl_members = get_acl_members(a)
-        if nick in acl_members or nick.lower() in [x.lower() for x in acl_members]:
+        if id in acl_members or nick.lower() in [x.lower() for x in acl_members]:
             return True
 
     return False
@@ -42,7 +42,7 @@ def verify_acl(message, acl):
         if settings.DISABLE_ACL:
             return True
 
-        allowed = is_acl_allowed(message.sender.handle, acl)
+        allowed = is_acl_allowed(message.sender.handle, message.sender.id, acl)
         if allowed:
             return True
         if hasattr(message, "data") and hasattr(message.data, "backend_supports_acl"):

--- a/will/acl.py
+++ b/will/acl.py
@@ -20,7 +20,7 @@ def get_acl_members(acl):
     return acl_members
 
 
-def is_acl_allowed(nick, id, acl):
+def is_acl_allowed(id, acl):
     if not getattr(settings, "ACL", None):
         logging.warning(
             "%s was just allowed to perform actions in %s because no ACL settings exist. This can be a security risk." % (

--- a/will/acl.py
+++ b/will/acl.py
@@ -20,7 +20,7 @@ def get_acl_members(acl):
     return acl_members
 
 
-def is_acl_allowed(id, acl):
+def is_acl_allowed(_id, acl):
     if not getattr(settings, "ACL", None):
         logging.warning(
             "%s was just allowed to perform actions in %s because no ACL settings exist. This can be a security risk." % (
@@ -31,7 +31,7 @@ def is_acl_allowed(id, acl):
         return True
     for a in acl:
         acl_members = get_acl_members(a)
-        if id in acl_members:
+        if _id in acl_members:
             return True
 
     return False

--- a/will/acl.py
+++ b/will/acl.py
@@ -42,7 +42,7 @@ def verify_acl(message, acl):
         if settings.DISABLE_ACL:
             return True
 
-        allowed = is_acl_allowed(message.sender.handle, message.sender.id, acl)
+        allowed = is_acl_allowed(message.sender.id, acl)
         if allowed:
             return True
         if hasattr(message, "data") and hasattr(message.data, "backend_supports_acl"):

--- a/will/acl.py
+++ b/will/acl.py
@@ -24,7 +24,7 @@ def is_acl_allowed(_id, acl):
     if not getattr(settings, "ACL", None):
         logging.warning(
             "%s was just allowed to perform actions in %s because no ACL settings exist. This can be a security risk." % (
-                nick,
+                _id,
                 acl,
             )
         )

--- a/will/acl.py
+++ b/will/acl.py
@@ -20,18 +20,18 @@ def get_acl_members(acl):
     return acl_members
 
 
-def is_acl_allowed(_id, acl):
+def is_acl_allowed(user_id, acl):
     if not getattr(settings, "ACL", None):
         logging.warning(
             "%s was just allowed to perform actions in %s because no ACL settings exist. This can be a security risk." % (
-                _id,
+                user_id,
                 acl,
             )
         )
         return True
     for a in acl:
         acl_members = get_acl_members(a)
-        if _id in acl_members:
+        if user_id in acl_members:
             return True
 
     return False

--- a/will/acl.py
+++ b/will/acl.py
@@ -31,7 +31,7 @@ def is_acl_allowed(id, acl):
         return True
     for a in acl:
         acl_members = get_acl_members(a)
-        if id in acl_members or nick.lower() in [x.lower() for x in acl_members]:
+        if id in acl_members:
             return True
 
     return False

--- a/will/scripts/config.py.dist
+++ b/will/scripts/config.py.dist
@@ -169,10 +169,24 @@ FUZZY_REGEX_ALLOWABLE_ERRORS = 3
 
 # Access Control: Specify groups of users to be used in the acl=["admins","ceos"] parameter
 # in respond_to and hear actions.
-# Group names can be any string, and the list is composed of user handles.
-# ACL = {
-#     "admins": ["sarah", "sue", "steven"]
-# }
+# Group names can be any string, and the list is composed of user ids.
+#
+# In slack the user ID can be found by visiting the link below, selecting your slack account
+# from the dropdown, and then clicking your @name next to the `user` field.
+# https://api.slack.com/methods/users.info/test
+#
+# In rocketchat the user ID can by found by visiting /account/tokens and generating a new
+# (temporary) personal access token, the user ID will be presented with the new token, which
+# can then be deleted.
+#
+#    ACL = {
+#        "admins":
+#            [
+#                "U2A06UQHX", #sarah
+#                "UXHQU60A2", #sue
+#                "UABC1234"   #steven
+#            ]
+#    }
 #
 # By default, if no ACL is set, all users can perform all actions - but warnings
 # will be printed to the console.  To disable those warnings, set DISABLE_ACL to True

--- a/will/scripts/config.py.dist
+++ b/will/scripts/config.py.dist
@@ -171,13 +171,8 @@ FUZZY_REGEX_ALLOWABLE_ERRORS = 3
 # in respond_to and hear actions.
 # Group names can be any string, and the list is composed of user ids.
 #
-# In slack the user ID can be found by visiting the link below, selecting your slack account
-# from the dropdown, and then clicking your @name next to the `user` field.
-# https://api.slack.com/methods/users.info/test
-#
-# In rocketchat the user ID can by found by visiting /account/tokens and generating a new
-# (temporary) personal access token, the user ID will be presented with the new token, which
-# can then be deleted.
+# See the ACL docs for help locating user ids.
+# http://skoczen.github.io/will/plugins/builtins/#access-control
 #
 #    ACL = {
 #        "admins":

--- a/will/tests/test_acl.py
+++ b/will/tests/test_acl.py
@@ -59,7 +59,7 @@ def settings_acl():
 def build_message_with_acls(person, message):
     def _build_message_with_acls(user_and_groups):
         user_id, groups = user_and_groups
-        p = person({"id": user_id, "handle": "testhandle"})
+        p = person({"id": user_id})
         m = message({"sender": p, "data": message({})})
 
         return m, groups
@@ -90,12 +90,12 @@ def test_get_acl_members(group, settings_acl):
 
 def test_is_acl_allowed_returns_true(allowed_message_with_acls):
     message, acls = allowed_message_with_acls
-    assert is_acl_allowed(message.sender.handle, message.sender.id, acls)
+    assert is_acl_allowed(message.sender.id, acls)
 
 
 def test_is_acl_allowed_returns_false(not_allowed_message_with_acls):
     message, acls = not_allowed_message_with_acls
-    assert not is_acl_allowed(message.sender.handle, message.sender.id, acls)
+    assert not is_acl_allowed(message.sender.id, acls)
 
 
 def test_verify_acl_is_disabled(not_allowed_message_with_acls):

--- a/will/tests/test_acl.py
+++ b/will/tests/test_acl.py
@@ -6,8 +6,8 @@ from will.acl import get_acl_members, is_acl_allowed, verify_acl
 
 # our mock ACL object, just as a user would add to Will's config.py
 ACL = {
-    'ENGINEERING_OPS': ['bob', 'Alice'],
-    'engineering_devs': ['eve']
+    'ENGINEERING_OPS': ['U2A06UQHX', 'UXHQU60A2'],           # slack style user ids
+    'engineering_devs': ['nSYqWzZ4GsKTX4dyK']                # rocketchat style user id
 }
 
 # More than one ACL group can be specified as allowed to trigger a `respond()`
@@ -16,20 +16,20 @@ ACL = {
 # https://docs.pytest.org/en/latest/fixture.html#parametrizing-fixtures
 
 VALID_USERS_AND_GROUPS = [
-    ('bob', {'ENGINEERING_OPS'}),
-    ('Alice', {'ENGINEERING_OPS'}),
-    ('eve', {'engineering_devs'}),
-    ('bob', {'ENGINEERING_OPS', 'engineering_devs'}),
-    ('Alice', {'ENGINEERING_OPS', 'engineering_devs'}),
-    ('eve', {'ENGINEERING_OPS', 'engineering_devs'})
+    ('U2A06UQHX', {'ENGINEERING_OPS'}),
+    ('UXHQU60A2', {'ENGINEERING_OPS'}),
+    ('nSYqWzZ4GsKTX4dyK', {'engineering_devs'}),
+    ('U2A06UQHX', {'ENGINEERING_OPS', 'engineering_devs'}),
+    ('UXHQU60A2', {'ENGINEERING_OPS', 'engineering_devs'}),
+    ('nSYqWzZ4GsKTX4dyK', {'ENGINEERING_OPS', 'engineering_devs'})
 ]
 
 INVALID_USERS_AND_GROUPS = [
-    ('bob', {'engineering_devs'}),
-    ('Alice', {'engineering_devs'}),
-    ('eve', {'ENGINEERING_OPS'}),
-    ('juan', {'ENGINEERING_OPS', 'engineering_devs'}),
-    ('pedro', {'ENGINEERING_OPS', 'engineering_devs'})
+    ('U2A06UQHX', {'engineering_devs'}),
+    ('UXHQU60A2', {'engineering_devs'}),
+    ('nSYqWzZ4GsKTX4dyK', {'ENGINEERING_OPS'}),
+    ('UABC1234', {'ENGINEERING_OPS', 'engineering_devs'}),
+    ('UDEF5678', {'ENGINEERING_OPS', 'engineering_devs'})
 ]
 
 
@@ -58,8 +58,8 @@ def settings_acl():
 @pytest.fixture()
 def build_message_with_acls(person, message):
     def _build_message_with_acls(user_and_groups):
-        user, groups = user_and_groups
-        p = person({"handle": user})
+        user_id, groups = user_and_groups
+        p = person({"id": user_id, "handle": "testhandle"})
         m = message({"sender": p, "data": message({})})
 
         return m, groups
@@ -90,12 +90,12 @@ def test_get_acl_members(group, settings_acl):
 
 def test_is_acl_allowed_returns_true(allowed_message_with_acls):
     message, acls = allowed_message_with_acls
-    assert is_acl_allowed(message.sender.handle, acls)
+    assert is_acl_allowed(message.sender.handle, message.sender.id, acls)
 
 
 def test_is_acl_allowed_returns_false(not_allowed_message_with_acls):
     message, acls = not_allowed_message_with_acls
-    assert not is_acl_allowed(message.sender.handle, acls)
+    assert not is_acl_allowed(message.sender.handle, message.sender.id, acls)
 
 
 def test_verify_acl_is_disabled(not_allowed_message_with_acls):


### PR DESCRIPTION
Fixes #394.

After looking at actually implementing the per IO-backend ACL configuration idea I realized that it would rely on the `message.sender.source` object the Slack backend populates with the email address among other fields. This object appears to be inconsistent among backends however. The rocketchat backend populates it with [only the username field](https://github.com/skoczen/will/blob/master/will/backends/io_adapters/rocketchat.py#L289). On further inspection I couldn't really work out what that source object is intended for and it seems to duplicate a bit of info already added to the Person object so I wasn't excited about the idea of bringing rocketchat in line with the slack backend on that front.

Since all three of the current IO backends do populate a unique identifier in the `.id` attribute it seemed the next best bet and it simplified the fix dramatically. Also, since this is the one little sliver of the app we have tests on I felt much better about poking around in there.