### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/docs/backends/generation.md
+++ b/docs/backends/generation.md
@@ -20,7 +20,7 @@ Here's a bit more about the built-ins, and when they'd be a good fit:
 
 #### Fuzzy Match (all) (`will.backends.generation.fuzzy_all_matches`)
 
-This uses the fantastic [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy) library to match strings with some fuzziness, as specified by `FUZZY_MINIMUM_MATCH_CONFIDENCE` (defaults to 90% confidence) and `FUZZY_REGEX_ALLOWABLE_ERRORS` (defaults to 3).
+This uses the fantastic [rapidfuzz](https://github.com/rhasspy/rapidfuzz) library to match strings with some fuzziness, as specified by `FUZZY_MINIMUM_MATCH_CONFIDENCE` (defaults to 90% confidence) and `FUZZY_REGEX_ALLOWABLE_ERRORS` (defaults to 3).
 
 Great if you'd like your Will to be a little flexible, sometimes get things wrong, but to handle typos.
 

--- a/will/backends/generation/fuzzy_all_matches.py
+++ b/will/backends/generation/fuzzy_all_matches.py
@@ -1,7 +1,7 @@
 import logging
 import regex
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process as fuzz_process
+from rapidfuzz import fuzz
+from rapidfuzz import process as fuzz_process
 from will import settings
 from will.decorators import require_settings
 from will.utils import Bunch
@@ -62,7 +62,11 @@ class FuzzyAllMatchesBackend(GenerationBackend):
                     self.match_methods[l["regex_pattern"]] = l
                     self.match_choices.append(l["regex_pattern"])
 
-            search_matches = fuzz_process.extract(message.content, self.match_choices)
+            search_matches = fuzz_process.extract(
+                message.content,
+                self.match_choices,
+                score_cutoff=settings.FUZZY_MINIMUM_MATCH_CONFIDENCE
+            )
 
             for match_str, confidence in search_matches:
                 logging.debug(" Potential (%s) - %s" % (confidence, match_str))

--- a/will/backends/generation/fuzzy_best_match.py
+++ b/will/backends/generation/fuzzy_best_match.py
@@ -1,5 +1,5 @@
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process as fuzz_process
+from rapidfuzz import fuzz
+from rapidfuzz import process as fuzz_process
 import regex
 from will import settings
 from will.decorators import require_settings

--- a/will/scripts/config.py.dist
+++ b/will/scripts/config.py.dist
@@ -111,7 +111,7 @@ EXECUTION_BACKENDS = [
 # ------------------------------------------------------------------------------------
 
 # Confidence fuzzy generation backends require before Will responds
-# https://pypi.python.org/pypi/fuzzywuzzy
+# https://pypi.python.org/pypi/rapidfuzz
 FUZZY_MINIMUM_MATCH_CONFIDENCE = 91
 FUZZY_REGEX_ALLOWABLE_ERRORS = 3
 


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy. (since apparently here python-Levenshtein