### PR TITLE
Fix Travis & Add Github Actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,27 @@
+name: Python package
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        pip install -r will/requirements/dev.txt
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 dist: xenial
 language: python
 python:
-  - '2.7'
-  - '3.4'
-  - '3.5'
   - '3.6'
   - '3.7'
+  - '3.8'
+  - '3.9'
 sudo: false
 services:
   - docker

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ for req_file in ["base.txt", "slack.txt", "hipchat.txt", "rocketchat.txt"]:
 
 tests_require = [
     'mock',
-    'pytest==4.6.6',
+    'pytest==6.2.2',
     'pytest-cov',
     'pytest-runner',
     'pytest-mock',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,13 @@
 [tox]
-envlist = py27, py34, py35, py36, py37
+envlist = py36, py37, py38, py39
 
+[gh-actions]
+python =
+    2.7: py27
+    3.6: py36
+    3.7: py37
+    3.8: py38, mypy
+    3.9: py39
 
 [testenv]
 deps =

--- a/will/plugins/productivity/remind.py
+++ b/will/plugins/productivity/remind.py
@@ -13,12 +13,9 @@ class RemindPlugin(WillPlugin):
             formatted_to_string = to_string
         else:
             formatted_to_string = ""
-        formatted_reminder_text = "%(mention_handle)s, you asked me to remind you%(to_string)s %(reminder_text)s" % {
-            "mention_handle": message.sender.mention_handle,
-            "from_handle": message.sender.handle,
-            "reminder_text": reminder_text,
-            "to_string": formatted_to_string,
-        }
+        formatted_reminder_text = f"{message.sender.mention_handle}s, you asked me to remind you " \
+                                  f"{formatted_to_string} {reminder_text}"
+
         self.schedule_say(formatted_reminder_text, parsed_time, message=message, notify=True)
         self.say("%(reminder_text)s %(natural_datetime)s. Got it." % locals(), message=message)
 

--- a/will/requirements/base.txt
+++ b/will/requirements/base.txt
@@ -1,28 +1,29 @@
 APScheduler==2.1.2
 beautifulsoup4==4.6.0
-bottle==0.12.7
+bottle==0.12.19
 CherryPy==3.6.0
-clint==0.3.7
-dill==0.2.1
+clint==0.5.1
+dill==0.3.3
 dnspython==1.15.0
 fuzzywuzzy==0.15.1
 Jinja2==2.7.3
-Markdown==2.3.1
+Markdown==3.3.4
 MarkupSafe==0.23
+# Temporary fork of natural, until python 3 support is merged: https://github.com/tehmaze/natural/pull/13
 # Temporary fork of natural, until python 3 support is merged: https://github.com/tehmaze/natural/pull/13
 # natural==0.2.1
 will-natural==0.2.1.1
 parsedatetime==1.1.2
-python-Levenshtein==0.12.0
+python-Levenshtein==0.12.1
 pyasn1-modules==0.0.5
 pyasn1==0.1.7
 pycrypto==2.6.1
 pygerduty==0.28
-pytz==2017.2
-PyYAML==3.13
+pytz==2021.1
+PyYAML==5.4.1
 regex==2017.9.23
 redis==2.10.6
-requests==2.20.0
-six==1.10.0
-urllib3==1.24.3
-websocket-client==0.44.0
+requests==2.25.0
+six==1.15.0
+urllib3==1.25.10
+aiohttp

--- a/will/requirements/dev.txt
+++ b/will/requirements/dev.txt
@@ -10,7 +10,7 @@ nose
 coverage
 yappi
 tox
-pytest==4.6.6
+pytest==6.2.2
 pytest-cov
 pytest-mock
 freezegun

--- a/will/tests/test_plugin.py
+++ b/will/tests/test_plugin.py
@@ -135,6 +135,8 @@ def test_get_backend_service_as_parameter(message, plugin, io_backend, all_io_ba
 # freeze_time to mock datetime.datetime.now() method which is invoked
 # when creating an event or message.
 # https://github.com/spulec/freezegun
+
+
 @freeze_time(WILLS_BIRTHDAY)
 def test_say_with_room_arg(plugin, content, say_event, source_message, outgoing_topic):
     room = "test"


### PR DESCRIPTION
- Fix travis-ci
- Add github actions ci
- Remove 2.7, 3.5 from ci
- Add 3.6, 3.7, 3.8, 3.9 to ci
- Various requirements changes to support current python & fix tests
- Fix flake8 errors

Travis is migrating away from travis-ci.org to travis-ci.com and changing how the free tier works. I would support moving away from travis and embracing github actions. But it doesn't hurt anything to run both for now.