### PR TITLE
Pin aiohttp version for slack_sdk

### DIFF
--- a/will/requirements/slack.txt
+++ b/will/requirements/slack.txt
@@ -1,4 +1,4 @@
 -r base.txt
 slack-sdk==3.0.0
 markdownify==0.5.3
-aiohttp
+aiohttp>=3.7.3,<4


### PR DESCRIPTION
Pinning the version of aiohttp to match that which slack_sdk depends on:

https://github.com/slackapi/python-slack-sdk/blob/main/setup.py#L301

