### PR TITLE
Support unsolicitied direct file uploads

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,8 +51,9 @@ acommasplice, https://github.com/acommasplice
 TaunoTinits, https://github.com/TaunoTinits
 ostracon, https://github.com/ostracon
 mattcl, https://github.com/mattcl
-Ahmed Osman, https://github.com/Ashex 
+Evelyn Osman, https://github.com/Ashex
 Boris Peterbarg, https://github.com/reist
 unicolet, https://github.com/unicolet
 Rob Salmond, https://github.com/rsalmond
 Jeremy Logan, https://github.com/fixedd
+Brian Gallew, https://github.com/BrianGallew

--- a/will/backends/io_adapters/slack.py
+++ b/will/backends/io_adapters/slack.py
@@ -78,6 +78,10 @@ class SlackBackend(
         for c in self.channels.values():
             if c.name.lower() == name.lower() or c.id.lower() == name.lower():
                 return c
+            # We need to check if a user id was passed as a channel
+            # and get the correct IM channel if it was.
+            elif name.startswith('U') or name.startswith('W'):
+                return self.open_direct_message(name)
         webclient = self.client._web_client  # pylint: disable=protected-access
         try:
             channel_info = webclient.conversations_info(channel=name)["channel"]
@@ -102,6 +106,22 @@ class SlackBackend(
             is_im=channel_info["is_im"],
             is_private=True,
         )
+
+    def get_channel_name_from_id(self, name):
+        for k, c in self.channels.items():
+            if c.name.lower() == name.lower() or c.id.lower() == name.lower():
+                return c.name
+
+    @staticmethod
+    def is_allowed_channel(channel):
+        if hasattr(settings, "SLACK_ROOMS"):
+            if channel.lower() in settings.SLACK_ROOMS:
+                return True
+            else:
+                logging.warning('Will has been added to {0} but it should not be here!'.format(channel))
+                return False
+        else:
+            return True
 
     def normalize_incoming_event(self, event):
         "Makes a Slack event look like all the other events we handle"
@@ -141,8 +161,21 @@ class SlackBackend(
             # u'type': u'message', u'bot_id': u'B5HL9ABFE'},
             # u'type': u'message', u'hidden': True, u'channel': u'D5HGP0YE7'}
             logging.debug("we like that event!")
-            sender = self.people[event["user"]]
-            channel = self.get_channel_from_name(event["channel"])
+            if event_subtype == "bot_message":
+                sender = Person(
+                    id=event["bot_id"],
+                    mention_handle="<@%s>" % event["bot_id"],
+                    handle=event["username"],
+                    source=event,
+                    name=event["username"],
+                )
+            else:
+                sender = self.people[event["user"]]
+            try:
+                channel = self.get_channel_from_name(event["channel"])
+            except KeyError:
+                self._update_channels()
+                channel = self.get_channel_from_name(event["channel"])
             is_private_chat = getattr(channel, "is_private", False)
             is_direct = getattr(getattr(channel, "source", None), 'is_im', False)
             channel = clean_for_pickling(channel)
@@ -169,7 +202,7 @@ class SlackBackend(
             if will_is_mentioned and event["text"][0] == ":":
                 event["text"] = event["text"][1:]
 
-            if event["user"] == self.me.id:
+            if event.get("user") == self.me.id:
                 will_said_it = True
 
             m = Message(
@@ -206,10 +239,14 @@ class SlackBackend(
 
         try:
             logging.info('EVENT: %s', str(event))
-            data = {
+            data = {}
+            if hasattr(event, "kwargs"):
+                data.update(event.kwargs)
+
+            data.update({
                 'filename': event.filename,
                 'filetype': event.filetype
-            }
+            })
             self.set_data_channel_and_thread(event, data)
             # This is just *silly*
             if 'thread_ts' in data:
@@ -303,6 +340,10 @@ class SlackBackend(
     @staticmethod
     def set_data_channel_and_thread(event, data=None):
         "Update data with the channel/thread information from event"
+        if event.type == "file.upload":
+            # We already know what to do when it's a file DM
+            if event.kwargs.get("is_direct") is True:
+                return
         if data is None:
             data = dict()
         if "channel" in event:
@@ -488,6 +529,13 @@ class SlackBackend(
         self.client._web_client.api_call(  # pylint: disable=protected-access
             "chat.postMessage", data=data
         )
+
+    def open_direct_message(self, user_id):
+        """Opens a DM channel."""
+        return self.client._web_client.api_call(  # pylint: disable=protected-access
+            "conversations.open",
+            users=[user_id]
+        )['channel']['id']
 
     def update_message(self, event):
         "Update a Slack message"

--- a/will/backends/io_adapters/slack.py
+++ b/will/backends/io_adapters/slack.py
@@ -112,17 +112,6 @@ class SlackBackend(
             if c.name.lower() == name.lower() or c.id.lower() == name.lower():
                 return c.name
 
-    @staticmethod
-    def is_allowed_channel(channel):
-        if hasattr(settings, "SLACK_ROOMS"):
-            if channel.lower() in settings.SLACK_ROOMS:
-                return True
-            else:
-                logging.warning('Will has been added to {0} but it should not be here!'.format(channel))
-                return False
-        else:
-            return True
-
     def normalize_incoming_event(self, event):
         "Makes a Slack event look like all the other events we handle"
         event_type = event.get("type")

--- a/will/plugin.py
+++ b/will/plugin.py
@@ -11,7 +11,6 @@ from will.mixins import NaturalTimeMixin, ScheduleMixin, StorageMixin, SettingsM
     EmailMixin, PubSubMixin
 
 
-
 class WillPlugin(EmailMixin, StorageMixin, NaturalTimeMixin,
                  ScheduleMixin, SettingsMixin, PubSubMixin):
     'Basic things needed by all plugins'

--- a/will/plugin.py
+++ b/will/plugin.py
@@ -10,7 +10,6 @@ from will.abstractions import Event, Message
 from will.mixins import NaturalTimeMixin, ScheduleMixin, StorageMixin, SettingsMixin, \
     EmailMixin, PubSubMixin
 
-FILENAME_CLEANER = re.compile(r'[^-_0-9a-zA-Z]+')
 
 
 class WillPlugin(EmailMixin, StorageMixin, NaturalTimeMixin,
@@ -114,7 +113,7 @@ class WillPlugin(EmailMixin, StorageMixin, NaturalTimeMixin,
             e = Event(
                 type="file.upload",
                 file=content,
-                filename=FILENAME_CLEANER.sub('_', filename),
+                filename=filename,
                 filetype=filetype,
                 source_message=message,
                 title=text,


### PR DESCRIPTION
Resolves #429 

Incorporate logic from #369 for sending direct messages and adding some logic to allow passing a user id into `send_file` that will trigger opening a direct message channel. This PR also adds support for handling messages from bots and webhooks.


 Example code:

```python

    @respond_to(r"send me a file")
    def test_send_file(self, message):
        """give me a file: Just send a file for testing."""
        r = requests.get('https://gist.githubusercontent.com/Ashex/703ef3311bcb4fa50d1268303f5b08ab/raw/87159c75045d723908488c0e9ce99774858f7fb2/guide.md')
        self.send_file(message=message, content=r.text, filename='readme.md', text='Here is your file!', 
                       filetype='text/markdown', is_direct=True, channel=self.get_user_id(message.sender.handle))

    def get_user_id(self, user_id):
        people_cache = self.load('slack_people_cache', {})
        for k, c in people_cache.items():
            if user_id == c.handle:
                logging.info(f'Found {c.id}')
                return c.id

```

Very open to feedback on this implimentation. 

CC: @pastorhudson 